### PR TITLE
Relase 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DiscordTwitterEmbedRX",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/discord/handler.ts
+++ b/src/discord/handler.ts
@@ -9,19 +9,15 @@ import { PostEmbed } from "./postEmbed";
 const TWITTER_URL_REGEX = /https:\/\/(x|twitter)\.com\/[A-Za-z_0-9]+\/status\/[0-9]+/g;
 const postEmbed = new PostEmbed();
 const tmpDir = "./tmp";
-const uniqueArr = <T>(arr: T[]): T[] => [...new Set(arr)];
 
 export async function onMessageCreate(client: Client<boolean>, m: Message) {
   if ((client.user !== null && m.author.id === client.user.id) || m.author.bot) return;
 
   // https://twitter.com(or x.com)/hogehoge/{postID}かチェック
   const matchRes = m.content.match(TWITTER_URL_REGEX);
-
   if (matchRes) {
-    // 配列内部の重複を除去する
-    const postURLs = uniqueArr(matchRes);
-    for (const i in postURLs) {
-      const tweetData = await getTweetData(postURLs[i]);
+    for (const i in matchRes) {
+      const tweetData = await getTweetData(matchRes[i]);
       if (tweetData == undefined) {
         await m.reply("ツイートの取得に失敗しました。");
         return;

--- a/src/discord/handler.ts
+++ b/src/discord/handler.ts
@@ -1,9 +1,13 @@
-import { Message, Client, ChannelType } from "discord.js";
-import { PostEmbed } from "../postEmbed";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Message, Client, ChannelType, AttachmentBuilder } from "discord.js";
 import { getTweetData } from "../shared/wrapper";
+import { downloadVideo } from "../utils/downloadVideo";
+import { PostEmbed } from "./postEmbed";
 
 const TWITTER_URL_REGEX = /https:\/\/(x|twitter)\.com\/[A-Za-z_0-9]+\/status\/[0-9]+/g;
 const postEmbed = new PostEmbed();
+const tmpDir = "./tmp";
 
 export async function onMessageCreate(client: Client<boolean>, m: Message) {
   if ((client.user !== null && m.author.id === client.user.id) || m.author.bot) return;
@@ -20,10 +24,66 @@ export async function onMessageCreate(client: Client<boolean>, m: Message) {
       // 投稿されたポストの埋め込みを削除する
       await m.suppressEmbeds(true);
 
+      // 一時ディレクトリ作成
+      await fs.mkdir(tmpDir);
+
+      await downloadMedia(tweetData.mediaUrls);
+
+      // ディレクトリからファイルを取り出し、AttachBuilderへ渡す
+      try {
+        const files = await fs.readdir(tmpDir);
+
+        // mp4ファイルがない場合はスキップする
+        if (files.length !== 0) {
+          const attachments = files.map((file) => {
+            const filePath = path.join(tmpDir, file);
+            return new AttachmentBuilder(filePath, { name: "mediaFile.mp4" });
+          });
+          if (m.channel.type === ChannelType.GuildText) {
+            await m.channel.send({
+              files: attachments,
+            });
+          }
+        }
+      } catch (e) {
+        console.error(`Error sending file: ${e}`);
+        if (m.channel.type === ChannelType.GuildText) {
+          await m.channel.send("ファイルの送信に失敗しました");
+          await m.channel.send(`${e}`);
+        }
+      }
+
+      // 埋め込みデータ生成
       const embedPostInfo = postEmbed.createEmbed(tweetData);
+
       if (m.channel.type === ChannelType.GuildText) {
         await m.channel.send({ embeds: embedPostInfo });
       }
+      // 一時ディレクトリ削除
+      await fs.rm(tmpDir, { recursive: true });
     }
   }
+}
+
+/**
+ * メディアデータをURLからダウンロードする
+ * @param mediaUrls string | undefined
+ * @returns void
+ */
+async function downloadMedia(mediaUrls?: string[]): Promise<void> {
+  let cnt = 1;
+  // mp4がある場合はダウンロードする
+  for (const url of mediaUrls ?? []) {
+    if (/\.mp4$/.test(url)) {
+      try {
+        console.log("start download...");
+        await downloadVideo(url, tmpDir + `/output${cnt}.mp4`);
+        console.log("download completed!");
+      } catch (error) {
+        console.error(`Error!: ${error}`);
+      }
+      cnt++;
+    }
+  }
+  return;
 }

--- a/src/discord/handler.ts
+++ b/src/discord/handler.ts
@@ -9,15 +9,19 @@ import { PostEmbed } from "./postEmbed";
 const TWITTER_URL_REGEX = /https:\/\/(x|twitter)\.com\/[A-Za-z_0-9]+\/status\/[0-9]+/g;
 const postEmbed = new PostEmbed();
 const tmpDir = "./tmp";
+const uniqueArr = <T>(arr: T[]): T[] => [...new Set(arr)];
 
 export async function onMessageCreate(client: Client<boolean>, m: Message) {
   if ((client.user !== null && m.author.id === client.user.id) || m.author.bot) return;
 
   // https://twitter.com(or x.com)/hogehoge/{postID}かチェック
   const matchRes = m.content.match(TWITTER_URL_REGEX);
+
   if (matchRes) {
-    for (const i in matchRes) {
-      const tweetData = await getTweetData(matchRes[i]);
+    // 配列内部の重複を除去する
+    const postURLs = uniqueArr(matchRes);
+    for (const i in postURLs) {
+      const tweetData = await getTweetData(postURLs[i]);
       if (tweetData == undefined) {
         await m.reply("ツイートの取得に失敗しました。");
         return;

--- a/src/discord/postEmbed.ts
+++ b/src/discord/postEmbed.ts
@@ -57,11 +57,11 @@ export class PostEmbed {
    * @returns
    */
   createEmbed(post: TweetData): EmbedBuilder[] {
-    if (post.mediaUrls == undefined || post.mediaUrls.length == 0) {
+    if (post.mediaUrlsThumbnail == undefined || post.mediaUrlsThumbnail.length == 0) {
       return [this.createSingleEmbed(post)];
     }
 
-    return post.mediaUrls.map((url) => {
+    return post.mediaUrlsThumbnail.map((url) => {
       return this.createSingleEmbed(post).setImage(url);
     });
   }

--- a/src/fxtwitter/fxtwitter.ts
+++ b/src/fxtwitter/fxtwitter.ts
@@ -41,6 +41,7 @@ export interface Media {
 
 export interface Photo {
   type: string;
+  thumbnail_url: string;
   url: string;
   width: number;
   height: number;

--- a/src/shared/converter.ts
+++ b/src/shared/converter.ts
@@ -23,7 +23,8 @@ export function VxToTweetData(data: VxTwitter, depth: number = 0): TweetData {
     tweetUrl: data.tweetURL,
     quoteData: data.qrt && depth < 1 ? VxToTweetData(data.qrt, depth + 1) : undefined,
     hasQuote: data.qrt != null,
-    mediaUrls: data.mediaURLs.map((_s, i) => (!/\.mp4$/.test(_s) ? _s : data.media_extended[i].thumbnail_url)),
+    mediaUrls: data.mediaURLs,
+    mediaUrlsThumbnail: data.mediaURLs.map((_s, i) => (!/\.mp4$/.test(_s) ? _s : data.media_extended[i].thumbnail_url)),
     hasMedia: data.mediaURLs != undefined,
     timestamp: new Date(data.date),
   };
@@ -52,6 +53,7 @@ export function FXToTweetData(data: Tweet, depth: number = 0): TweetData {
     timestamp: new Date(data.created_at),
     tweetUrl: data.url,
     mediaUrls: data.media != undefined ? data.media.photos.map((p) => p.url) : undefined,
+    mediaUrlsThumbnail: data.media != undefined ? data.media.photos.map((p) => p.thumbnail_url) : undefined,
     quoteData: data.quote != undefined && depth < 1 ? FXToTweetData(data.quote, depth + 1) : undefined,
   };
 }

--- a/src/shared/tweetdata.ts
+++ b/src/shared/tweetdata.ts
@@ -10,6 +10,7 @@ export interface TweetData {
   timestamp: Date;
   hasMedia: boolean;
   mediaUrls: string[] | undefined;
+  mediaUrlsThumbnail: string[] | undefined;
 }
 
 export interface TweetAuthor {

--- a/src/utils/downloadVideo.ts
+++ b/src/utils/downloadVideo.ts
@@ -1,0 +1,33 @@
+import { createWriteStream } from "fs";
+import * as http from "http";
+import * as https from "https";
+
+export function downloadVideo(url: string, outputPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith("https") ? https : http;
+
+    client
+      .get(url, (response: http.IncomingMessage) => {
+        if (response.statusCode !== 200) {
+          // メモリリーク防止
+          response.resume();
+          reject(new Error(`Failed to download file: ${response.statusCode}`));
+          return;
+        }
+
+        // 書き込みストリーム作成
+        const fileStream = createWriteStream(outputPath);
+        // ストリームへデータをパイプする
+        response.pipe(fileStream);
+
+        fileStream.on("finish", () => {
+          fileStream.close();
+          console.log(`Download complete: ${outputPath}`);
+          resolve();
+        });
+      })
+      .on("error", (err: Error) => {
+        reject(err);
+      });
+  });
+}


### PR DESCRIPTION
- handlerにあるツイート投稿に関する処理をサービスへ切り出し
- tmpディレクトリの設定を相対パスから、絶対パスに変更
- CJSからESMへ移行
- ESM移行に伴い、npm run debug の処理を tsx で行うように変更
- メッセージに対する処理を通常の投稿から、ユーザーに対するリプライに変更
- 重複するURLを除去する (https://github.com/t1nyb0x/discord-twitter-embed-rx/issues/58 対応）