### PR TITLE
Discordの添付サイズ制限対策：5MB以上のデータはURLを直接貼り付ける形に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
       "dependencies": {
         "@discordjs/builders": "^1.9.0",
         "axios": "^1.7.7",
-        "discord.js": "^14.16.3"
+        "discord.js": "^14.16.3",
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.1",
+        "@types/js-yaml": "^4.0.9",
         "@typescript-eslint/eslint-plugin": "^8.11.0",
         "@typescript-eslint/parser": "^8.11.0",
         "eslint": "^9.13.0",
@@ -913,6 +915,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1277,7 +1286,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -3292,7 +3300,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "homepage": "https://github.com/t1nyb0x/discord-twitter-embed-rx#readme",
   "devDependencies": {
     "@eslint/compat": "^1.2.1",
+    "@types/js-yaml": "^4.0.9",
     "@typescript-eslint/eslint-plugin": "^8.11.0",
     "@typescript-eslint/parser": "^8.11.0",
     "eslint": "^9.13.0",
@@ -51,14 +52,15 @@
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
-    "tsc-alias": "^1.8.10",
-    "typescript": "^5.6.3",
     "ts-node": "^10.9.2",
-    "tsx": "^4.19.3"
+    "tsc-alias": "^1.8.10",
+    "tsx": "^4.19.3",
+    "typescript": "^5.6.3"
   },
   "dependencies": {
     "@discordjs/builders": "^1.9.0",
     "axios": "^1.7.7",
-    "discord.js": "^14.16.3"
+    "discord.js": "^14.16.3",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,0 +1,1 @@
+media_max_file_size: 5242800 # Discordに添付するメディアファイルの上限サイズ 5MB

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,8 +1,22 @@
+import fs from "node:fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import yaml from "js-yaml";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// ルートディレクトリ（index.ts のディレクトリ）を固定
+// ルートディレクトリ取得
 export const ROOT_DIR = path.dirname(__dirname);
+
+const configPath = path.join(ROOT_DIR, "/config.yml");
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let config: any = {};
+try {
+  const fileContents = fs.readFileSync(configPath, "utf8");
+  config = yaml.load(fileContents);
+} catch (e) {
+  console.error("設定ファイルの読み込みに失敗しました。config.ymlを確認してください", e);
+}
+
+export default { MEDIA_MAX_FILE_SIZE: config.media_max_file_size };

--- a/src/utils/filterMedia.ts
+++ b/src/utils/filterMedia.ts
@@ -1,0 +1,52 @@
+import https from "https";
+import config from "../config/config";
+
+export class FilterMedia {
+  /**
+   * URLのファイルサイズを返す
+   * @param url
+   * @returns number ファイルサイズ
+   */
+  private getFileSize(url: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const req = https.request(url, { method: "HEAD" }, (res) => {
+        const contentLength = res.headers["content-length"];
+
+        if (contentLength) {
+          resolve(parseInt(contentLength, 10));
+        } else {
+          reject(new Error("Could not get Content-Length Header... "));
+        }
+      });
+
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  /**
+   * MEDIA_MAX_FILE_SIZEで指定したサイズより小さいものと大きいもので分ける
+   * @param mediaUrls
+   * @returns {validUrls: string[]; invalidUrls: string[]} validUrls - MEDIA_MAX_FILE_SIZEより小さいデータURL配列 invalidUrls - MEDIA_MAX_FILE_SIZEより大きなデータURL配列
+   */
+  async mediaSizeFilter(mediaUrls: string[]): Promise<{ validUrls: string[]; invalidUrls: string[] }> {
+    const validUrls: string[] = [];
+    const invalidUrls: string[] = [];
+
+    await Promise.all(
+      mediaUrls.map(async (url) => {
+        try {
+          const fileSize = await this.getFileSize(url);
+          if (fileSize <= config.MEDIA_MAX_FILE_SIZE) {
+            validUrls.push(url);
+          } else {
+            invalidUrls.push(url);
+          }
+        } catch (error) {
+          console.error(new Error(`Error checking file size ${error}`));
+        }
+      })
+    );
+    return { validUrls: validUrls, invalidUrls: invalidUrls };
+  }
+}


### PR DESCRIPTION
#102 対応