### PR TITLE
ヘルスチェック用 HTTP エンドポイントの追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,13 @@ REDIS_URL=
 # 省略時は config.yml の設定を使用
 LOG_LEVEL=info
 
+# === Health Check Server ===
+
+# ヘルスチェックHTTPサーバーのポート番号
+# デフォルト: 9090
+# Docker HEALTHCHECK / Kubernetes livenessProbe/readinessProbe で使用
+HEALTH_PORT=9090
+
 # === Phase 2: Channel Config フォールバック設定 ===
 
 # Redis障害時のデフォルト動作

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,57 +5,22 @@ on:
     branches: ["main", "develop"]
 
 jobs:
-  setup:
+  test:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24.x
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build shared package
         run: npm run build:shared
-
-      - name: Cache node_modules
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            packages/shared/dist
-          key: deps-${{ github.run_id }}
-
-  test:
-    runs-on: ubuntu-latest
-    needs: setup
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-
-      - name: Restore node_modules
-        id: restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            packages/shared/dist
-          key: deps-${{ github.run_id }}
-
-      - name: Install dependencies (fallback)
-        if: steps.restore.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline
 
       - name: Run oxlint
         run: npx oxlint src/
@@ -79,24 +44,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24.x
+          cache: "npm"
 
-      - name: Restore node_modules
-        id: restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            packages/shared/dist
-          key: deps-${{ github.run_id }}
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Install dependencies (fallback)
-        if: steps.restore.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline
+      - name: Build shared package
+        run: npm run build:shared
 
       - name: Build TypeScript
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           node-version: 24.x
 
       - name: Restore node_modules
+        id: restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -51,6 +52,10 @@ jobs:
             packages/*/node_modules
             packages/shared/dist
           key: deps-${{ github.run_id }}
+
+      - name: Install dependencies (fallback)
+        if: steps.restore.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline
 
       - name: Run oxlint
         run: npx oxlint src/
@@ -80,6 +85,7 @@ jobs:
           node-version: 24.x
 
       - name: Restore node_modules
+        id: restore
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -87,6 +93,10 @@ jobs:
             packages/*/node_modules
             packages/shared/dist
           key: deps-${{ github.run_id }}
+
+      - name: Install dependencies (fallback)
+        if: steps.restore.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline
 
       - name: Build TypeScript
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main", "develop"]
 
 jobs:
-  test:
+  setup:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,6 +21,41 @@ jobs:
 
       - name: Build shared package
         run: npm run build:shared
+
+      - name: Cache node_modules
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            packages/shared/dist
+          key: deps-${{ hashFiles('package-lock.json') }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: setup
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      - name: Restore node_modules
+        id: restore
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            packages/shared/dist
+          key: deps-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies (fallback)
+        if: steps.restore.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline && npm run build:shared
 
       - name: Run oxlint
         run: npx oxlint src/
@@ -49,11 +84,19 @@ jobs:
           node-version: 24.x
           cache: "npm"
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore node_modules
+        id: restore
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            packages/shared/dist
+          key: deps-${{ hashFiles('package-lock.json') }}
 
-      - name: Build shared package
-        run: npm run build:shared
+      - name: Install dependencies (fallback)
+        if: steps.restore.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline && npm run build:shared
 
       - name: Build TypeScript
         run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,8 @@ RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/.config ./.config
 
+# ヘルスチェック（HEALTH_PORT=9090 で /healthz エンドポイントを確認）
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:9090/healthz || exit 1
+
 CMD ["npm", "run", "start:docker"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2292,7 +2292,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4240,7 +4242,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4282,7 +4286,7 @@
     },
     "packages/shared": {
       "name": "@twitterrx/shared",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
       ],
       "dependencies": {
         "@discordjs/builders": "^1.9.0",
+        "@hono/node-server": "^2.0.4",
         "@twitterrx/shared": "*",
         "chalk": "^5.3.0",
         "discord.js": "^14.26.3",
+        "hono": "^4.12.25",
         "js-yaml": "^4.1.0",
         "redis": "^5.7.0",
         "winston": "^3.17.0",
@@ -708,6 +710,18 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.4.tgz",
+      "integrity": "sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2561,6 +2575,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-escaper": {

--- a/package.json
+++ b/package.json
@@ -62,9 +62,11 @@
   },
   "dependencies": {
     "@discordjs/builders": "^1.9.0",
+    "@hono/node-server": "^2.0.4",
     "@twitterrx/shared": "*",
     "chalk": "^5.3.0",
     "discord.js": "^14.26.3",
+    "hono": "^4.12.25",
     "js-yaml": "^4.1.0",
     "redis": "^5.7.0",
     "winston": "^3.17.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { TweetProcessor } from "@/core/services/TweetProcessor";
 import { RedisChannelConfigRepository } from "@/infrastructure/db/RedisChannelConfigRepository";
 import { RedisReplyLogger } from "@/infrastructure/db/RedisReplyLogger";
 import { FileManager } from "@/infrastructure/filesystem/FileManager";
+import { HealthServer } from "@/infrastructure/http/HealthServer";
+import type { HealthCheckDependencies } from "@/infrastructure/http/HealthServer";
 import { HttpClient } from "@/infrastructure/http/HttpClient";
 import { VideoDownloader } from "@/infrastructure/http/VideoDownloader";
 import { cleanupOrphanedConfigs } from "@/utils/cleanupOrphanedConfigs";
@@ -20,6 +22,7 @@ import logger from "@/utils/logger";
 
 import config, { ROOT_DIR } from "./config/config";
 import { connectRedis } from "./db/connect";
+import { redis } from "./db/init";
 import { deleteReply, popReply } from "./db/replyLogger";
 
 enum ApplicationMode {
@@ -44,6 +47,9 @@ switch (ENV) {
 }
 logger.info(`Application started in ${appMode} mode`);
 logger.info(`Version: ${version}`);
+
+// === Health Server ===
+let healthServer: HealthServer | undefined;
 
 // === Load bot token from environ variable ===
 let token: string | undefined;
@@ -282,6 +288,15 @@ client.on("guildDelete", async (guild) => {
 // === Login ===
 (async () => {
   await connectRedis();
+
+  // ヘルスチェックサーバー起動（Redis 接続後に起動）
+  const healthDeps: HealthCheckDependencies = {
+    isRedisReady: () => redis.isReady,
+    isDiscordReady: () => client.isReady(),
+  };
+  healthServer = new HealthServer(healthDeps, undefined, version);
+  await healthServer.start();
+
   await client.login(token);
 })();
 
@@ -313,6 +328,11 @@ process.on("SIGTERM", async () => {
 
 async function shutdown(): Promise<void> {
   try {
+    // ヘルスチェックサーバー停止
+    if (healthServer) {
+      await healthServer.stop();
+    }
+
     // Channel Config Service のシャットダウン
     await channelConfigService.shutdown();
 

--- a/src/infrastructure/http/HealthServer.ts
+++ b/src/infrastructure/http/HealthServer.ts
@@ -1,0 +1,153 @@
+import http from "node:http";
+
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+
+import logger from "@/utils/logger";
+
+/**
+ * ヘルスチェックで確認する依存コンポーネントの状態取得関数群
+ */
+export interface HealthCheckDependencies {
+  isRedisReady: () => boolean;
+  isDiscordReady: () => boolean;
+}
+
+export interface HealthCheckResult {
+  status: "healthy" | "degraded";
+  version: string;
+  uptime: number;
+  checks: {
+    redis: boolean;
+    discord: boolean;
+  };
+}
+
+/**
+ * ヘルスチェック用 HTTP サーバー
+ *
+ * 提供するエンドポイント:
+ *   GET /healthz  - Liveness Probe（常に200）
+ *   GET /readyz   - Readiness Probe（依存が全て READY なら200、それ以外は503）
+ *   GET /health   - 詳細なヘルス情報（JSON）
+ *
+ * デフォルトポートは 9090。環境変数 HEALTH_PORT で上書き可能。
+ *
+ * 内部実装には Hono を使用しており、テスト時は `honoApp` から `app.request()` を
+ * 直接呼び出すことでサーバー起動なしにリクエストを発行できる。
+ */
+export class HealthServer {
+  readonly honoApp: Hono;
+  private server: http.Server | undefined;
+  private port: number;
+
+  constructor(deps: HealthCheckDependencies, port?: number, appVersion?: string) {
+    this.port = port ?? (Number(process.env.HEALTH_PORT) || 9090);
+    this.honoApp = this.buildApp(deps, appVersion ?? "unknown");
+  }
+
+  // ============================================================
+  // Hono アプリケーションの構築
+  // ============================================================
+
+  private buildApp(deps: HealthCheckDependencies, version: string): Hono {
+    const app = new Hono();
+
+    // GET /healthz — Liveness Probe
+    app.get("/healthz", (c) => {
+      return c.json({ status: "ok" });
+    });
+
+    // GET /readyz — Readiness Probe
+    app.get("/readyz", (c) => {
+      const redis = deps.isRedisReady();
+      const discord = deps.isDiscordReady();
+      const ready = redis && discord;
+
+      return c.json(
+        { status: ready ? "ok" : "not ready", checks: { redis, discord } },
+        ready ? 200 : 503,
+      );
+    });
+
+    // GET /health — Full Health
+    app.get("/health", (c) => {
+      const redis = deps.isRedisReady();
+      const discord = deps.isDiscordReady();
+      const healthy = redis && discord;
+
+      const body: HealthCheckResult = {
+        status: healthy ? "healthy" : "degraded",
+        version,
+        uptime: process.uptime(),
+        checks: { redis, discord },
+      };
+
+      return c.json(body, healthy ? 200 : 503);
+    });
+
+    // 404 fallback
+    app.notFound((c) => {
+      return c.json({ error: "not found" }, 404);
+    });
+
+    return app;
+  }
+
+  // ============================================================
+  // ライフサイクル
+  // ============================================================
+
+  /**
+   * 実際にリッスンしているポート番号。start() 呼び出し前は undefined。
+   */
+  get listeningPort(): number | undefined {
+    if (!this.server) return undefined;
+    const addr = this.server.address();
+    if (addr && typeof addr === "object") {
+      return addr.port;
+    }
+    return undefined;
+  }
+
+  /**
+   * ヘルスチェックサーバーを起動する
+   */
+  start(): Promise<void> {
+    return new Promise((resolve) => {
+      this.server = serve(
+        {
+          fetch: this.honoApp.fetch,
+          port: this.port,
+          hostname: "0.0.0.0",
+        },
+        (info) => {
+          logger.info(`[HealthServer] Listening on 0.0.0.0:${info.port}`);
+          resolve();
+        },
+      );
+    });
+  }
+
+  /**
+   * ヘルスチェックサーバーを停止する
+   */
+  async stop(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close((err) => {
+        if (err) {
+          logger.error(`[HealthServer] Error during shutdown: ${err.message}`);
+          reject(err);
+          return;
+        }
+        logger.info("[HealthServer] Stopped");
+        this.server = undefined;
+        resolve();
+      });
+    });
+  }
+}

--- a/src/infrastructure/http/HealthServer.ts
+++ b/src/infrastructure/http/HealthServer.ts
@@ -1,6 +1,5 @@
-import http from "node:http";
-
 import { serve } from "@hono/node-server";
+import type { ServerType } from "@hono/node-server";
 import { Hono } from "hono";
 
 import logger from "@/utils/logger";
@@ -38,7 +37,7 @@ export interface HealthCheckResult {
  */
 export class HealthServer {
   readonly honoApp: Hono;
-  private server: http.Server | undefined;
+  private server: ServerType | undefined;
   private port: number;
 
   constructor(deps: HealthCheckDependencies, port?: number, appVersion?: string) {

--- a/src/infrastructure/http/HealthServer.ts
+++ b/src/infrastructure/http/HealthServer.ts
@@ -64,10 +64,7 @@ export class HealthServer {
       const discord = deps.isDiscordReady();
       const ready = redis && discord;
 
-      return c.json(
-        { status: ready ? "ok" : "not ready", checks: { redis, discord } },
-        ready ? 200 : 503,
-      );
+      return c.json({ status: ready ? "ok" : "not ready", checks: { redis, discord } }, ready ? 200 : 503);
     });
 
     // GET /health — Full Health
@@ -124,7 +121,7 @@ export class HealthServer {
         (info) => {
           logger.info(`[HealthServer] Listening on 0.0.0.0:${info.port}`);
           resolve();
-        },
+        }
       );
     });
   }

--- a/tests/unit/infrastructure/HealthServer.test.ts
+++ b/tests/unit/infrastructure/HealthServer.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HealthServer } from "@/infrastructure/http/HealthServer";
+
+import type { HealthCheckDependencies } from "@/infrastructure/http/HealthServer";
+
+// logger をモック
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const createMockDeps = (
+  overrides: Partial<HealthCheckDependencies> = {},
+): HealthCheckDependencies => ({
+  isRedisReady: vi.fn().mockReturnValue(true),
+  isDiscordReady: vi.fn().mockReturnValue(true),
+  ...overrides,
+});
+
+describe("HealthServer", () => {
+  let server: HealthServer;
+  let deps: HealthCheckDependencies;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+    server = new HealthServer(deps, 0);
+  });
+
+  afterEach(async () => {
+    try {
+      await server.stop();
+    } catch {
+      // 停止済みの場合は無視
+    }
+  });
+
+  // -----------------------------------------------------------
+  // Hono アプリケーションの直接テスト (app.request)
+  // -----------------------------------------------------------
+  describe("Hono routes", () => {
+    // /healthz — Liveness Probe
+    describe("GET /healthz", () => {
+      it("should return 200 with status ok", async () => {
+        const res = await server.honoApp.request("/healthz");
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ status: "ok" });
+      });
+    });
+
+    // /readyz — Readiness Probe
+    describe("GET /readyz", () => {
+      it("should return 200 when all dependencies are ready", async () => {
+        const res = await server.honoApp.request("/readyz");
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({
+          status: "ok",
+          checks: { redis: true, discord: true },
+        });
+      });
+
+      it("should return 503 when Redis is not ready", async () => {
+        deps.isRedisReady = vi.fn().mockReturnValue(false);
+        const res = await server.honoApp.request("/readyz");
+        expect(res.status).toBe(503);
+        expect(await res.json()).toMatchObject({
+          status: "not ready",
+          checks: { redis: false, discord: true },
+        });
+      });
+
+      it("should return 503 when Discord is not ready", async () => {
+        deps.isDiscordReady = vi.fn().mockReturnValue(false);
+        const res = await server.honoApp.request("/readyz");
+        expect(res.status).toBe(503);
+        expect(await res.json()).toMatchObject({
+          status: "not ready",
+          checks: { redis: true, discord: false },
+        });
+      });
+
+      it("should return 503 when both dependencies are not ready", async () => {
+        deps.isRedisReady = vi.fn().mockReturnValue(false);
+        deps.isDiscordReady = vi.fn().mockReturnValue(false);
+        const res = await server.honoApp.request("/readyz");
+        expect(res.status).toBe(503);
+        expect(await res.json()).toMatchObject({
+          status: "not ready",
+          checks: { redis: false, discord: false },
+        });
+      });
+    });
+
+    // /health — Full Health Check
+    describe("GET /health", () => {
+      it("should return 200 with full details when healthy", async () => {
+        const res = await server.honoApp.request("/health");
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toMatchObject({
+          status: "healthy",
+          checks: { redis: true, discord: true },
+        });
+        expect(body).toHaveProperty("version");
+        expect(body).toHaveProperty("uptime");
+      });
+
+      it("should return 503 with degraded status when Redis is down", async () => {
+        deps.isRedisReady = vi.fn().mockReturnValue(false);
+        const res = await server.honoApp.request("/health");
+        expect(res.status).toBe(503);
+        expect(await res.json()).toMatchObject({
+          status: "degraded",
+          checks: { redis: false, discord: true },
+        });
+      });
+
+      it("should include app version string", async () => {
+        const s = new HealthServer(deps, 0, "1.0.0-test");
+        const res = await s.honoApp.request("/health");
+        const body = await res.json();
+        expect(body).toMatchObject({ version: "1.0.0-test" });
+      });
+    });
+
+    // 404 — unknown paths
+    describe("unknown path", () => {
+      it("should return 404 for unknown paths", async () => {
+        const res = await server.honoApp.request("/unknown");
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "not found" });
+      });
+    });
+  });
+
+  // -----------------------------------------------------------
+  // 実サーバーの起動 / 停止
+  // -----------------------------------------------------------
+  describe("start / stop", () => {
+    it("should start and stop without error", async () => {
+      await server.start();
+      expect(server.listeningPort).toBeGreaterThan(0);
+      await expect(server.stop()).resolves.toBeUndefined();
+    });
+
+    it("should use default port 9090 when no port specified and no env var", () => {
+      delete process.env.HEALTH_PORT;
+      const s = new HealthServer(deps);
+      expect((s as unknown as { port: number }).port).toBe(9090);
+    });
+
+    it("should use HEALTH_PORT env var when no constructor port given", () => {
+      process.env.HEALTH_PORT = "8080";
+      const s = new HealthServer(deps);
+      expect((s as unknown as { port: number }).port).toBe(8080);
+      delete process.env.HEALTH_PORT;
+    });
+
+    it("should prefer constructor port over env var", () => {
+      process.env.HEALTH_PORT = "8080";
+      const s = new HealthServer(deps, 3000);
+      expect((s as unknown as { port: number }).port).toBe(3000);
+      delete process.env.HEALTH_PORT;
+    });
+  });
+
+  // -----------------------------------------------------------
+  // 実サーバー経由（結合動作確認）
+  // -----------------------------------------------------------
+  describe("real HTTP server", () => {
+    it("should handle healthz via actual server", async () => {
+      await server.start();
+      const res = await server.honoApp.request(`http://127.0.0.1:${server.listeningPort}/healthz`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ status: "ok" });
+    });
+  });
+});


### PR DESCRIPTION
Related: #466 

### 概要

Bot のヘルスチェックを行うための HTTP サーバーを実装しました。
Docker HEALTHCHECK / Kubernetes livenessProbe・readinessProbe での利用を想定しています。

### 背景

これまで Discord Bot (`twitter-rx`) は純粋な Discord クライアントとして動作しており、プロセスが正常に稼働しているか・トラフィックを受け付けられる状態かを外部から確認する手段がありませんでした。コンテナ環境でのデプロイが前提のため、Docker HEALTHCHECK や死活監視に対応する必要がありました。

### 変更内容

#### 新規ファイル

- **`src/infrastructure/http/HealthServer.ts`**
  Hono ベースの軽量 HTTP サーバー。`0.0.0.0:9090` で起動し、以下のエンドポイントを提供します。

  | パス | 用途 | ステータスコード |
  |---|---|---|
  | `GET /healthz` | Liveness Probe — プロセス生存確認 | 常に `200` |
  | `GET /readyz` | Readiness Probe — 依存の準備完了確認 | `200` / `503` |
  | `GET /health` | Full Health — バージョン・稼働時間を含む詳細JSON | `200` / `503` |

- **`tests/unit/infrastructure/HealthServer.test.ts`**
  14 ケースのユニットテスト（Hono routes 9 + start/stop 4 + 実サーバー結合 1）

#### 変更ファイル

- **`src/index.ts`**
  - `HealthServer` の DI 登録
  - Redis 接続成功後に HealthServer を起動
  - Graceful shutdown 時に HealthServer を停止

- **`package.json`**
  - `hono`, `@hono/node-server` を依存関係に追加

- **`.env.example`**
  - `HEALTH_PORT` 環境変数を追加（デフォルト: `9090`）

- **`Dockerfile`**
  - `HEALTHCHECK` 命令を追加（interval=30s, timeout=5s, start-period=10s, retries=3）

### 設計意図

| 項目 | 判断 |
|---|---|
| **フレームワーク** | Hono を採用。テスト容易性 (`app.request()` でポート不要) と将来の拡張性を考慮 |
| **依存追加** | `hono` + `@hono/node-server` の 2 パッケージ。軽量 (~20KB) |
| **ポートの優先順位** | 引数 > `HEALTH_PORT` 環境変数 > デフォルト `9090` |
| **0.0.0.0 バインド** | コンテナ環境で外部からのプローブを受けられるようにする |
| **graceful shutdown** | Bot 停止前にヘルスチェックサーバーを閉じ、トラフィックを切り離す |

### 動作確認

- 全 14 テストパス
- `oxlint` 0 warnings / 0 errors
- `tsc --noEmit` で新規コード起因の型エラーなし

### 補足

Bot の readiness は Redis の接続状態 (`redis.isReady`) と Discord クライアントの状態 (`client.isReady()`) の両方が真の場合に `200` を返します。どちらかが未準備の場合は `503` を返します。

