### PR TITLE
feat: ユーザーBAN・サーバーBAN・脱退機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ PRODUCTION_TOKEN=
 DEVELOP_TOKEN=
 REDIS_URL=
 
+# Owner Discord User ID (DM から Bot 管理コマンドを実行するための必須設定)
+OWNER_USER_ID=
+
 # ログレベル (debug, info, warn, error)
 # config.yml の設定よりも優先されます
 # 省略時は config.yml の設定を使用

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,165 @@
+# AGENTS.md — TwitterRX (discord-twitter-embed-rx)
+
+## プロジェクト概要
+
+- Discord Bot。Twitter/X の URL を検出し、vxTwitter/FxTwitter API から内容を取得して Embed 展開する。
+- TypeScript モノレポ (npm workspaces: `packages/*`)。
+- Dashboard (Web UI) は Git サブモジュール（別リポジトリ `t1nyb0x/discord-twitter-embed-rx-dashboard`）。
+
+## 技術スタック
+
+| 項目 | 技術 |
+|------|------|
+| ランタイム | Node.js 24+ |
+| 言語 | TypeScript (ES2022, strict) |
+| Bot フレームワーク | discord.js v14 |
+| キャッシュ / Pub/Sub | Redis 8 (ioredis) |
+| テスト | Vitest |
+| Lint / Format | oxlint / oxfmt |
+| パッケージ管理 | npm workspaces |
+
+## ディレクトリ構成
+
+```
+src/
+├── adapters/           # 外部サービスとの接続
+│   ├── discord/        #   EmbedBuilder, MessageHandler
+│   └── twitter/        #   FxTwitterAdapter, VxTwitterAdapter, TwitterAdapter
+├── config/             # アプリ設定 (config.ts)
+├── core/               # ビジネスロジック（依存性なし）
+│   ├── models/         #   Tweet 型定義 (ADT)
+│   └── services/       #   TweetProcessor, MediaHandler, ChannelConfigService
+├── db/                 # Redis 接続・初期化
+├── fxtwitter/          # FxTwitter API クライアント
+├── infrastructure/     # 外部リソース実装
+│   ├── db/             #   RedisChannelConfigRepository, RedisReplyLogger
+│   ├── filesystem/     #   FileManager
+│   └── http/           #   HttpClient, HealthServer, VideoDownloader
+├── utils/              # ユーティリティ (logger, cleanupOrphanedConfigs)
+├── vxtwitter/          # VxTwitter API クライアント
+└── index.ts            # エントリポイント（DI コンテナ兼用）
+tests/
+├── unit/               # 単体テスト（モック使用）
+├── integration/        # 結合テスト
+├── e2e/                # E2E テスト
+└── fixtures/           # テストフィクスチャ
+packages/
+└── shared/             # Bot・Dashboard 共通パッケージ @twitterrx/shared
+```
+
+## アーキテクチャ原則
+
+### レイヤー構造（Clean Architecture 的）
+
+```
+[Core] ← [Application/Adapters] ← [Infrastructure] ← [External]
+```
+
+- **Core** (`src/core/`): ビジネスロジック。外部依存ゼロ。Pure TypeScript。
+- **Adapters** (`src/adapters/`): Core と外部の橋渡し。インターフェース定義＋実装。
+- **Infrastructure** (`src/infrastructure/`): 外部リソース (Redis, HTTP, FS) の具体的実装。
+- **Entry Point** (`src/index.ts`): DI のルート。全依存性を手動で注入する。
+
+### 依存性注入パターン
+
+```typescript
+// コンストラクタインジェクションが基本
+const repository = new RedisChannelConfigRepository();
+const service = new ChannelConfigService(repository); // 依存性を注入
+
+// TwitterAdapter はファクトリメソッド
+const adapter = TwitterAdapter.createDefault(); // ← 内部で Vx/Fx を compositon
+```
+
+**ルール**: `src/index.ts` でのみ DI ワイヤリングを行う。それ以外のファイルで new による依存解決をしない。
+
+## 品質ゲート（必須）
+
+以下のゲートをすべて通過した状態でなければコミット・マージしてはならない。
+
+| ゲート | コマンド | 内容 |
+|--------|----------|------|
+| **Lint** | `npm run lint` (oxlint) | `src/` 以下の全 TypeScript を oxlint でチェック。警告・エラーともにゼロ必須。 |
+| **Compile** | `npm run compile:test` (tsc --noEmit) | TypeScript コンパイルエラーゼロ。パスエイリアス `@/` の解決も含む。 |
+| **Build** | `npm run build` | 本番ビルドが正常に完了すること（clean → shared ビルド → tsc → tsc-alias）。 |
+
+実装・変更を行ったら、作業完了前に必ず `npm run lint` (`oxlint src/`) と `npm run compile:test` (`tsc --noEmit`) を実行し、通過を確認する。
+
+## コミットメッセージ規約
+
+コミットメッセージは **Conventional Commits** に従うこと。
+
+```
+<type>(<scope>): <description>
+```
+
+| type       | 使用場面 |
+|------------|----------|
+| `feat`     | 新機能 |
+| `fix`      | バグ修正 |
+| `chore`    | ビルド・タスク・依存関係 |
+| `docs`     | ドキュメントのみの変更 |
+| `refactor` | リファクタリング（動作変更なし） |
+| `test`     | テストの追加・修正 |
+| `style`    | フォーマットのみ（動作変更なし） |
+| `ci`       | CI 設定の変更 |
+| `perf`     | パフォーマンス改善 |
+| `revert`   | 変更の打ち消し |
+
+scope は省略可能。description は日本語でも英語でもよいが、簡潔に変更内容を表すこと。
+
+**例:**
+- `feat(dashboard): チャンネル設定画面を追加`
+- `fix: vxTwitter API のタイムアウト処理を修正`
+- `docs: AGENTS.md にコミット規約を追加`
+- `refactor(core): TweetProcessor の判定ロジックを整理`
+
+この規約に違反するコミットは amend または rebase で修正すること。
+
+## コーディング規約
+
+### 全般
+
+- 言語: 日本語（README / コメント / コミットメッセージ）、ただし既存の英文コメントは翻訳しない。
+- 命名: `camelCase`（変数/関数）、`PascalCase`（クラス/型/インターフェース）、`UPPER_CASE`（enum 値/定数）。
+- 型定義は `interface` 優先。`type` は Union 型など interface で表現できない場合のみ。
+- ファイル名: `PascalCase.ts`（クラス/コンポーネント）、`camelCase.ts`（関数/ユーティリティ）。
+- パスエイリアス: `@/` → `./src/`（tsconfig paths + vitest alias で解決）。
+
+### 非同期処理
+
+- `async/await` 一貫使用。生の `.then()` / `.catch()` は禁止。
+- エラーハンドリングは try-catch で明示的に行い、logger にスタックトレースを含める。
+- Graceful shutdown 必須: SIGINT/SIGTERM で Redis → Discord Client の順にクローズ。
+
+### テスト
+
+- **t-wada スタイルの TDD**: 実装と同時に型チェック + テストで動作検証。
+- テスト配置: `tests/unit/` に src と同じディレクトリ構造で配置。
+- モック: 外部依存 (Redis, Discord, HTTP) はテスト用の Mock クラスを使用。
+- テストランナー: Vitest（globals: true, sourceMap 対応）。
+- カバレッジ: vitest --coverage（v8 provider）。
+
+### Redis キー命名規則
+
+```
+app:<domain>:<id>:<field>
+```
+
+例:
+- `app:guild:{guildId}:joined` — 参加フラグ
+- `app:guild:{guildId}:channels` — チャンネルキャッシュ
+- `app:config:{guildId}:{channelId}` — チャンネル設定
+
+### エラーハンドリング
+
+- logger.error には structured metadata を含める（`{ error: ..., context: ... }`）。
+- 起動時の致命的エラーは `throw new Error(...)`。runtime のエラーは catch して logger に記録、ボットは継続。
+- 外部 API (vxTwitter/FxTwitter) のエラーはフォールバック可能にする（片方が落ちてももう片方でリトライ）。
+
+## 注意点 / 制約
+
+- `packages/shared/` は Dashboard との共通コード。Bot 側の変更時は Dashboard 互換性に注意。
+- Dashboard は Git サブモジュール。`dashboard/` 以下は別リポジトリ。
+- compose.yml は開発用、compose.yml.example は本番デプロイ用（GHCR）。
+- `.config/` ディレクトリにアプリ設定ファイル。

--- a/src/adapters/discord/MessageHandler.ts
+++ b/src/adapters/discord/MessageHandler.ts
@@ -16,6 +16,7 @@ import {
 
 import { ITwitterAdapter } from "@/adapters/twitter/BaseTwitterAdapter";
 import { Tweet } from "@/core/models/Tweet";
+import { BanService } from "@/core/services/BanService";
 import { ChannelConfigService } from "@/core/services/ChannelConfigService";
 import { MediaHandler } from "@/core/services/MediaHandler";
 import { TweetProcessor } from "@/core/services/TweetProcessor";
@@ -53,7 +54,8 @@ export class MessageHandler {
     private readonly videoDownloader: IVideoDownloader,
     private readonly replyLogger: IReplyLogger,
     private readonly tmpDirBase: string,
-    private readonly channelConfigService?: ChannelConfigService
+    private readonly channelConfigService?: ChannelConfigService,
+    private readonly banService?: BanService
   ) {}
 
   /**
@@ -67,6 +69,15 @@ export class MessageHandler {
     // ボットメッセージや自身のメッセージは無視
     if (this.shouldIgnore(client, message)) {
       return;
+    }
+
+    // P0: ユーザー BAN チェック
+    if (this.banService) {
+      const isBanned = await this.banService.isUserBanned(message.author.id);
+      if (isBanned) {
+        logger.debug(`[MessageHandler] User ${message.author.id} is banned, ignoring message`);
+        return;
+      }
     }
 
     // P0: チャンネル許可チェック

--- a/src/adapters/discord/OwnerCommandHandler.ts
+++ b/src/adapters/discord/OwnerCommandHandler.ts
@@ -1,0 +1,320 @@
+import type { Client, Message } from "discord.js";
+
+import type { BanEntry } from "@/core/models/BanEntry";
+import { BanService } from "@/core/services/BanService";
+import logger from "@/utils/logger";
+
+/**
+ * Owner コマンドのパース結果
+ */
+interface ParsedCommand {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Discord DM 経由の Bot 管理者専用コマンドハンドラー
+ *
+ * 対応コマンド:
+ *   !owner/ban <userId> [reason]            — ユーザーを BAN（Bot がそのユーザーを無視）
+ *   !owner/unban <userId>                   — ユーザー BAN 解除
+ *   !owner/ban-guild <guildId> [reason]     — サーバーを BAN して脱退
+ *   !owner/unban-guild <guildId>            — サーバー BAN 解除
+ *   !owner/leave <guildId>                  — BAN なしで脱退のみ
+ *   !owner/list-bans                        — BAN 一覧（ユーザー + サーバー）
+ *   !owner/guilds                           — Bot 参加サーバー一覧
+ *   !owner/help                             — コマンド一覧表示
+ */
+export class OwnerCommandHandler {
+  private readonly COMMAND_PREFIX = "!owner/";
+
+  constructor(
+    private readonly ownerUserId: string,
+    private readonly banService: BanService,
+    private readonly client: Client
+  ) {}
+
+  /**
+   * メッセージが Owner コマンドかどうかを判定し、該当すれば処理する
+   *
+   * @returns コマンドを処理した場合は true、それ以外は false
+   */
+  async handleMessage(message: Message): Promise<boolean> {
+    // DM 以外は無視
+    if (message.guildId !== null) return false;
+
+    // Owner 以外は無視
+    if (message.author.id !== this.ownerUserId) return false;
+
+    // Bot メッセージは無視
+    if (message.author.bot) return false;
+
+    const parsed = this.parseCommand(message.content);
+    if (!parsed) return false;
+
+    logger.info(`[OwnerCmd] Received owner command: ${parsed.command}`, {
+      args: parsed.args,
+      userId: message.author.id,
+    });
+
+    try {
+      switch (parsed.command) {
+        case "ban":
+          await this.handleBan(message, parsed.args);
+          break;
+        case "unban":
+          await this.handleUnban(message, parsed.args);
+          break;
+        case "ban-guild":
+          await this.handleBanGuild(message, parsed.args);
+          break;
+        case "unban-guild":
+          await this.handleUnbanGuild(message, parsed.args);
+          break;
+        case "leave":
+          await this.handleLeave(message, parsed.args);
+          break;
+        case "list-bans":
+          await this.handleListBans(message);
+          break;
+        case "guilds":
+          await this.handleListGuilds(message);
+          break;
+        case "help":
+          await this.sendHelp(message);
+          break;
+        default:
+          await message.reply(
+            `不明なコマンドです: ${parsed.command}\nコマンド一覧は \`!owner/help\` を参照してください。`
+          );
+      }
+    } catch (error) {
+      logger.error(`[OwnerCmd] Error executing command ${parsed.command}:`, error);
+      await message.reply(`エラーが発生しました: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    return true;
+  }
+
+  /**
+   * メッセージ内容をコマンドと引数にパースする
+   */
+  private parseCommand(content: string): ParsedCommand | null {
+    const trimmed = content.trim();
+    if (!trimmed.startsWith(this.COMMAND_PREFIX)) return null;
+
+    const withoutPrefix = trimmed.slice(this.COMMAND_PREFIX.length);
+    const parts = withoutPrefix.split(/\s+/);
+    const command = parts[0]?.toLowerCase();
+    if (!command) return null;
+
+    const args = parts.slice(1).filter((a) => a.length > 0);
+    return { command, args };
+  }
+
+  /**
+   * !owner/ban <userId> [reason] — ユーザー BAN
+   */
+  private async handleBan(message: Message, args: string[]): Promise<void> {
+    if (args.length === 0) {
+      await message.reply("使用方法: `!owner/ban <userId> [reason]`");
+      return;
+    }
+
+    const [userId, ...reasonParts] = args;
+    const reason = reasonParts.length > 0 ? reasonParts.join(" ") : "理由未指定";
+
+    const result = await this.banService.banUser(userId, reason, message.author.id);
+
+    await message.reply(result.message);
+  }
+
+  /**
+   * !owner/unban <userId> — ユーザー BAN 解除
+   */
+  private async handleUnban(message: Message, args: string[]): Promise<void> {
+    if (args.length === 0) {
+      await message.reply("使用方法: `!owner/unban <userId>`");
+      return;
+    }
+
+    const [userId] = args;
+    const result = await this.banService.unbanUser(userId);
+    await message.reply(result.message);
+  }
+
+  /**
+   * !owner/ban-guild <guildId> [reason] — サーバー BAN + 脱退
+   */
+  private async handleBanGuild(message: Message, args: string[]): Promise<void> {
+    if (args.length === 0) {
+      await message.reply("使用方法: `!owner/ban-guild <guildId> [reason]`");
+      return;
+    }
+
+    const [guildId, ...reasonParts] = args;
+    const reason = reasonParts.length > 0 ? reasonParts.join(" ") : "理由未指定";
+
+    const result = await this.banService.banGuild(guildId, reason, message.author.id);
+
+    // Bot が対象サーバーに参加中なら脱退
+    const guild = this.client.guilds.cache.get(guildId);
+    if (guild) {
+      try {
+        await guild.leave();
+        logger.info(`[OwnerCmd] Left guild ${guildId} (${guild.name}) after guild ban`);
+      } catch (leaveErr) {
+        logger.error(`[OwnerCmd] Failed to leave guild ${guildId}:`, leaveErr);
+        await message.reply(`${result.message}\nただし、サーバーからの脱退に失敗しました。手動で確認してください。`);
+        return;
+      }
+    }
+
+    await message.reply(result.message);
+  }
+
+  /**
+   * !owner/unban-guild <guildId> — サーバー BAN 解除
+   */
+  private async handleUnbanGuild(message: Message, args: string[]): Promise<void> {
+    if (args.length === 0) {
+      await message.reply("使用方法: `!owner/unban-guild <guildId>`");
+      return;
+    }
+
+    const [guildId] = args;
+    const result = await this.banService.unbanGuild(guildId);
+    await message.reply(result.message);
+  }
+
+  /**
+   * !owner/leave <guildId>
+   */
+  private async handleLeave(message: Message, args: string[]): Promise<void> {
+    if (args.length === 0) {
+      await message.reply("使用方法: `!owner/leave <guildId>`");
+      return;
+    }
+
+    const [guildId] = args;
+    const guild = this.client.guilds.cache.get(guildId);
+
+    if (!guild) {
+      await message.reply(`サーバー ${guildId} には参加していません。`);
+      return;
+    }
+
+    try {
+      await guild.leave();
+      logger.info(`[OwnerCmd] Left guild ${guildId} (${guild.name}) via leave command`);
+      await message.reply(`サーバー ${guildId} (${guild.name}) から脱退しました。`);
+    } catch (error) {
+      logger.error(`[OwnerCmd] Failed to leave guild ${guildId}:`, error);
+      await message.reply(`脱退に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * !owner/list-bans
+   */
+  private async handleListBans(message: Message): Promise<void> {
+    const bans = await this.banService.listBans();
+
+    if (bans.length === 0) {
+      await message.reply("現在 BAN されている対象はありません。");
+      return;
+    }
+
+    const lines = bans.map((b: BanEntry, i: number) => {
+      const badge = b.targetType === "user" ? "👤" : "🏠";
+      const info = b.targetType === "guild" ? `(${this.client.guilds.cache.get(b.targetId)?.name ?? "未参加"})` : "";
+      return `**${i + 1}.** ${badge} \`${b.targetId}\` ${info}\n  種別: ${b.targetType === "user" ? "ユーザー" : "サーバー"}, 理由: ${b.reason}\n  日時: ${b.bannedAt}`;
+    });
+
+    const chunks = this.chunkText(lines.join("\n"), 1900);
+    for (const chunk of chunks) {
+      await message.reply(chunk);
+    }
+  }
+
+  /**
+   * !owner/guilds
+   */
+  private async handleListGuilds(message: Message): Promise<void> {
+    const guilds = this.client.guilds.cache;
+
+    if (guilds.size === 0) {
+      await message.reply("Bot は現在どのサーバーにも参加していません。");
+      return;
+    }
+
+    const lines = guilds.map(
+      (g: { id: string; name: string; memberCount: number }) => `\`${g.id}\` — ${g.name} (メンバー: ${g.memberCount})`
+    );
+
+    const guildBans = await this.banService.listBans("guild");
+    const bannedIds = new Set(guildBans.map((b: BanEntry) => b.targetId));
+
+    const header = `**参加サーバー一覧 (${guilds.size}件)**\n`;
+    const guildList = lines.join("\n");
+
+    let banNotice = "";
+    const bannedInGuilds = guilds.filter((g: { id: string }) => bannedIds.has(g.id));
+    if (bannedInGuilds.size > 0) {
+      banNotice = `\n\n⚠ BAN 済みサーバーが ${bannedInGuilds.size}件 含まれています（自動脱退待機中）。`;
+    }
+
+    const fullText = header + guildList + banNotice;
+
+    const chunks = this.chunkText(fullText, 1900);
+    for (const chunk of chunks) {
+      await message.reply(chunk);
+    }
+  }
+
+  /**
+   * !owner/help
+   */
+  private async sendHelp(message: Message): Promise<void> {
+    const helpText = [
+      "**Owner コマンド一覧**",
+      "",
+      "`!owner/ban <userId> [reason]`",
+      "  ユーザーを BAN します。BAN されたユーザーからの投稿は Bot が無視します。",
+      "",
+      "`!owner/unban <userId>`",
+      "  ユーザーの BAN を解除します。",
+      "",
+      "`!owner/ban-guild <guildId> [reason]`",
+      "  サーバーを BAN して脱退します。再招待されても自動脱退します。",
+      "",
+      "`!owner/unban-guild <guildId>`",
+      "  サーバーの BAN を解除します。",
+      "",
+      "`!owner/leave <guildId>`",
+      "  BAN 記録なしでサーバーから脱退します。",
+      "",
+      "`!owner/list-bans`",
+      "  BAN されているユーザー・サーバーの一覧を表示します。",
+      "",
+      "`!owner/guilds`",
+      "  Bot が参加しているサーバーの一覧を表示します。",
+      "",
+      "`!owner/help`",
+      "  このヘルプを表示します。",
+    ].join("\n");
+
+    await message.reply(helpText);
+  }
+
+  /**
+   * 長いテキストを指定文字数で分割する
+   */
+  private chunkText(text: string, maxLength: number): string[] {
+    const chunks: string[] = [];
+    for (let i = 0; i < text.length; i += maxLength) {
+      chunks.push(text.slice(i, i + maxLength));
+    }
+    return chunks;
+  }
+}

--- a/src/core/models/BanEntry.ts
+++ b/src/core/models/BanEntry.ts
@@ -1,0 +1,50 @@
+/**
+ * BAN エントリの型定義
+ *
+ * Bot 管理者がユーザーまたはサーバーを BAN した際の記録。
+ * Core レイヤーに属するため、外部依存なし。
+ */
+
+/** BAN 対象の種別 */
+export type BanTargetType = "user" | "guild";
+
+/**
+ * 1件の BAN レコード
+ */
+export interface BanEntry {
+  /** BAN された対象の ID（userId または guildId） */
+  targetId: string;
+  /** BAN 対象の種別 */
+  targetType: BanTargetType;
+  /** BAN 理由（任意） */
+  reason: string;
+  /** BAN を実行した管理者の Discord ユーザーID */
+  bannedBy: string;
+  /** BAN 実行日時（ISO 8601） */
+  bannedAt: string;
+}
+
+/**
+ * BAN 永続化リポジトリのインターフェース
+ * Adapter / Infrastructure 層で実装する
+ */
+export interface IBanRepository {
+  /** 対象を BAN リストに追加する */
+  addBan(entry: BanEntry): Promise<void>;
+  /** 対象の BAN を解除する */
+  removeBan(targetId: string, targetType: BanTargetType): Promise<void>;
+  /** 対象が BAN されているか確認する */
+  isBanned(targetId: string, targetType: BanTargetType): Promise<boolean>;
+  /** 全 BAN エントリを取得する（targetType でフィルタ可能） */
+  listBans(targetType?: BanTargetType): Promise<BanEntry[]>;
+  /** 1件の BAN 情報を取得する */
+  getBan(targetId: string, targetType: BanTargetType): Promise<BanEntry | null>;
+}
+
+/**
+ * BAN リスト操作の結果
+ */
+export interface BanOperationResult {
+  success: boolean;
+  message: string;
+}

--- a/src/core/services/BanService.ts
+++ b/src/core/services/BanService.ts
@@ -1,0 +1,110 @@
+import type { BanEntry, BanOperationResult, BanTargetType, IBanRepository } from "@/core/models/BanEntry";
+
+/**
+ * BAN に関するビジネスロジック
+ *
+ * Core レイヤー: 外部依存なし。リポジトリ経由でデータを操作する。
+ */
+export class BanService {
+  constructor(private readonly repository: IBanRepository) {}
+
+  /**
+   * 対象（ユーザーまたはサーバー）を BAN する。
+   * 既に BAN 済みの場合は何もしない。
+   */
+  async ban(
+    targetId: string,
+    targetType: BanTargetType,
+    reason: string,
+    bannedBy: string
+  ): Promise<BanOperationResult> {
+    const alreadyBanned = await this.repository.isBanned(targetId, targetType);
+    if (alreadyBanned) {
+      const label = targetType === "user" ? "ユーザー" : "サーバー";
+      return { success: false, message: `${label} ${targetId} は既に BAN されています。` };
+    }
+
+    const entry: BanEntry = {
+      targetId,
+      targetType,
+      reason,
+      bannedBy,
+      bannedAt: new Date().toISOString(),
+    };
+
+    await this.repository.addBan(entry);
+    const label = targetType === "user" ? "ユーザー" : "サーバー";
+    return { success: true, message: `${label} ${targetId} を BAN しました。` };
+  }
+
+  /**
+   * ユーザーを BAN する便利メソッド
+   */
+  async banUser(userId: string, reason: string, bannedBy: string): Promise<BanOperationResult> {
+    return this.ban(userId, "user", reason, bannedBy);
+  }
+
+  /**
+   * サーバーを BAN する便利メソッド
+   */
+  async banGuild(guildId: string, reason: string, bannedBy: string): Promise<BanOperationResult> {
+    return this.ban(guildId, "guild", reason, bannedBy);
+  }
+
+  /**
+   * 対象の BAN を解除する。BAN されていない場合は何もしない。
+   */
+  async unban(targetId: string, targetType: BanTargetType): Promise<BanOperationResult> {
+    const isBanned = await this.repository.isBanned(targetId, targetType);
+    if (!isBanned) {
+      const label = targetType === "user" ? "ユーザー" : "サーバー";
+      return { success: false, message: `${label} ${targetId} は BAN されていません。` };
+    }
+
+    await this.repository.removeBan(targetId, targetType);
+    const label = targetType === "user" ? "ユーザー" : "サーバー";
+    return { success: true, message: `${label} ${targetId} の BAN を解除しました。` };
+  }
+
+  /**
+   * ユーザーの BAN を解除する便利メソッド
+   */
+  async unbanUser(userId: string): Promise<BanOperationResult> {
+    return this.unban(userId, "user");
+  }
+
+  /**
+   * サーバーの BAN を解除する便利メソッド
+   */
+  async unbanGuild(guildId: string): Promise<BanOperationResult> {
+    return this.unban(guildId, "guild");
+  }
+
+  /**
+   * ユーザーが BAN されているか判定する
+   */
+  async isUserBanned(userId: string): Promise<boolean> {
+    return this.repository.isBanned(userId, "user");
+  }
+
+  /**
+   * サーバーが BAN されているか判定する
+   */
+  async isGuildBanned(guildId: string): Promise<boolean> {
+    return this.repository.isBanned(guildId, "guild");
+  }
+
+  /**
+   * BAN リストを取得する（targetType でフィルタ可能）
+   */
+  async listBans(targetType?: BanTargetType): Promise<BanEntry[]> {
+    return this.repository.listBans(targetType);
+  }
+
+  /**
+   * 1件の BAN 情報を取得する
+   */
+  async getBan(targetId: string, targetType: BanTargetType): Promise<BanEntry | null> {
+    return this.repository.getBan(targetId, targetType);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,13 @@ import { Client, GatewayIntentBits, Message, Partials, ChannelType } from "disco
 
 import { DiscordEmbedBuilder } from "@/adapters/discord/EmbedBuilder";
 import { MessageHandler } from "@/adapters/discord/MessageHandler";
+import { OwnerCommandHandler } from "@/adapters/discord/OwnerCommandHandler";
 import { TwitterAdapter } from "@/adapters/twitter/TwitterAdapter";
+import { BanService } from "@/core/services/BanService";
 import { ChannelConfigService } from "@/core/services/ChannelConfigService";
 import { MediaHandler } from "@/core/services/MediaHandler";
 import { TweetProcessor } from "@/core/services/TweetProcessor";
+import { RedisBanRepository } from "@/infrastructure/db/RedisBanRepository";
 import { RedisChannelConfigRepository } from "@/infrastructure/db/RedisChannelConfigRepository";
 import { RedisReplyLogger } from "@/infrastructure/db/RedisReplyLogger";
 import { FileManager } from "@/infrastructure/filesystem/FileManager";
@@ -69,6 +72,13 @@ if (token === undefined) {
   logger.info("Successfully loaded discord bot token");
 }
 
+// === Check owner user id ===
+const ownerUserId = process.env.OWNER_USER_ID;
+if (!ownerUserId) {
+  throw new Error("OWNER_USER_ID environment variable is not set");
+}
+logger.info(`Owner user ID: ${ownerUserId}`);
+
 // === Dependency Injection Setup ===
 const tmpDir = path.join(path.dirname(ROOT_DIR), "tmp");
 
@@ -89,6 +99,10 @@ const mediaHandler = new MediaHandler(httpClient, config.MEDIA_MAX_FILE_SIZE);
 // Adapter層
 const twitterAdapter = TwitterAdapter.createDefault();
 const embedBuilder = new DiscordEmbedBuilder();
+// Owner Command / Ban System
+const banRepository = new RedisBanRepository();
+const banService = new BanService(banRepository);
+
 const messageHandler = new MessageHandler(
   tweetProcessor,
   twitterAdapter,
@@ -98,7 +112,8 @@ const messageHandler = new MessageHandler(
   videoDownloader,
   replyLogger,
   tmpDir,
-  channelConfigService
+  channelConfigService,
+  banService
 );
 
 // === Create discord bot client ===
@@ -112,6 +127,9 @@ const client = new Client({
   ],
   partials: [Partials.Message, Partials.Channel],
 });
+
+// Owner Command Handler
+const ownerCommandHandler = new OwnerCommandHandler(ownerUserId, banService, client);
 
 // === Event handlers ===
 // On ready
@@ -130,6 +148,17 @@ client.on("clientReady", async () => {
 
   // P0: guildCreate - joined フラグとチャンネルキャッシュを設定
   for (const [guildId, guild] of client.guilds.cache) {
+    // P0: BAN チェック — BAN されていたら即座に脱退
+    if (await banService.isGuildBanned(guildId)) {
+      logger.warn(`[Bot] Found banned guild ${guildId} (${guild.name}) during startup, leaving immediately`);
+      try {
+        await guild.leave();
+      } catch (leaveErr) {
+        logger.error(`[Bot] Failed to leave banned guild ${guildId} during startup:`, leaveErr);
+      }
+      continue;
+    }
+
     try {
       const redis = (await import("@/db/init")).redis;
 
@@ -201,7 +230,11 @@ client.on("clientReady", async () => {
 });
 
 // On Message Create
-client.on("messageCreate", (m: Message) => {
+client.on("messageCreate", async (m: Message) => {
+  // Owner DM コマンドのルーティング
+  const isOwnerCommand = await ownerCommandHandler.handleMessage(m);
+  if (isOwnerCommand) return; // Owner コマンドはここで完了
+
   messageHandler.handleMessage(client, m).catch((error) => {
     logger.error("Error handling message:", { error: error.message, stack: error.stack });
   });
@@ -237,6 +270,17 @@ client.on("messageDelete", async (m) => {
 
 // P0: guildCreate - Bot が新しいサーバーに参加した時
 client.on("guildCreate", async (guild) => {
+  // P0: BAN チェック — BAN されていたら即座に脱退
+  if (await banService.isGuildBanned(guild.id)) {
+    logger.warn(`[Bot] Attempted to join banned guild ${guild.id} (${guild.name}), leaving immediately`);
+    try {
+      await guild.leave();
+    } catch (leaveErr) {
+      logger.error(`[Bot] Failed to leave banned guild ${guild.id}:`, leaveErr);
+    }
+    return;
+  }
+
   try {
     const redis = (await import("@/db/init")).redis;
 

--- a/src/infrastructure/db/RedisBanRepository.ts
+++ b/src/infrastructure/db/RedisBanRepository.ts
@@ -1,0 +1,98 @@
+import type { BanEntry, BanTargetType, IBanRepository } from "@/core/models/BanEntry";
+import { redis } from "@/db/init";
+import logger from "@/utils/logger";
+
+const BAN_SET_KEY = "app:ban:list";
+const BAN_META_PREFIX_USER = "app:ban:user:";
+const BAN_META_PREFIX_GUILD = "app:ban:guild:";
+
+/** Set に保存する複合キー: "{targetType}:{targetId}" */
+const setMember = (targetId: string, targetType: BanTargetType): string => `${targetType}:${targetId}`;
+/** メタデータの Redis キー */
+const metaKey = (targetId: string, targetType: BanTargetType): string =>
+  targetType === "user" ? `${BAN_META_PREFIX_USER}${targetId}` : `${BAN_META_PREFIX_GUILD}${targetId}`;
+
+/**
+ * Redis を使用した BAN リスト永続化リポジトリ
+ *
+ * キー設計:
+ *   app:ban:list           → Set of "user:{userId}" / "guild:{guildId}"（全件検索用）
+ *   app:ban:user:{userId}  → JSON（BanEntry）
+ *   app:ban:guild:{guildId} → JSON（BanEntry）
+ *
+ * user と guild で同じ Set を使うことで listBans() を1回の sMembers で済ませる。
+ * フィルタリングはアプリケーション側で行う。
+ */
+export class RedisBanRepository implements IBanRepository {
+  /**
+   * 対象を BAN リストに追加する
+   */
+  async addBan(entry: BanEntry): Promise<void> {
+    await redis.sAdd(BAN_SET_KEY, setMember(entry.targetId, entry.targetType));
+    await redis.set(metaKey(entry.targetId, entry.targetType), JSON.stringify(entry));
+    logger.info(`[BanRepo] Added ${entry.targetType} ban for ${entry.targetId}`, {
+      reason: entry.reason,
+      bannedBy: entry.bannedBy,
+    });
+  }
+
+  /**
+   * 対象の BAN を解除する
+   */
+  async removeBan(targetId: string, targetType: BanTargetType): Promise<void> {
+    await redis.sRem(BAN_SET_KEY, setMember(targetId, targetType));
+    await redis.del(metaKey(targetId, targetType));
+    logger.info(`[BanRepo] Removed ${targetType} ban for ${targetId}`);
+  }
+
+  /**
+   * 対象が BAN されているか確認する
+   */
+  async isBanned(targetId: string, targetType: BanTargetType): Promise<boolean> {
+    const result = await redis.sIsMember(BAN_SET_KEY, setMember(targetId, targetType));
+    return result === 1;
+  }
+
+  /**
+   * 全 BAN エントリを取得する（targetType でフィルタ可能）
+   */
+  async listBans(targetType?: BanTargetType): Promise<BanEntry[]> {
+    const members = await redis.sMembers(BAN_SET_KEY);
+    if (members.length === 0) return [];
+
+    // targetType でフィルタ
+    const filtered = targetType ? members.filter((m: string) => m.startsWith(`${targetType}:`)) : members;
+
+    const entries = await Promise.all(
+      filtered.map(async (member: string) => {
+        const [type, ...rest] = member.split(":");
+        const id = rest.join(":");
+        const json = await redis.get(metaKey(id, type as BanTargetType));
+        if (!json) return null;
+        try {
+          return JSON.parse(json) as BanEntry;
+        } catch {
+          logger.error(`[BanRepo] Failed to parse ban entry for ${member}`);
+          return null;
+        }
+      })
+    );
+
+    return entries.filter((e: BanEntry | null): e is BanEntry => e !== null);
+  }
+
+  /**
+   * 1件の BAN 情報を取得する
+   */
+  async getBan(targetId: string, targetType: BanTargetType): Promise<BanEntry | null> {
+    const json = await redis.get(metaKey(targetId, targetType));
+    if (!json) return null;
+
+    try {
+      return JSON.parse(json) as BanEntry;
+    } catch {
+      logger.error(`[BanRepo] Failed to parse ban entry for ${targetType} ${targetId}`);
+      return null;
+    }
+  }
+}

--- a/tests/unit/adapters/discord/OwnerCommandHandler.test.ts
+++ b/tests/unit/adapters/discord/OwnerCommandHandler.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { OwnerCommandHandler } from "@/adapters/discord/OwnerCommandHandler";
+import { BanService } from "@/core/services/BanService";
+
+// Collection ライクな Map（.map() / .filter() / .size を生やす）
+class MockCollection<K, V> extends Map<K, V> {
+  map<T>(fn: (value: V, key: K) => T): T[] {
+    const result: T[] = [];
+    for (const [key, value] of this.entries()) {
+      result.push(fn(value, key));
+    }
+    return result;
+  }
+
+  filter(fn: (value: V, key: K) => boolean): MockCollection<K, V> {
+    const result = new MockCollection<K, V>();
+    for (const [key, value] of this.entries()) {
+      if (fn(value, key)) result.set(key, value);
+    }
+    return result;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockClient = (): any => ({
+  user: { id: "bot-id" },
+  guilds: {
+    cache: new MockCollection<string, any>(),
+  },
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockMessage = (overrides: Record<string, unknown> = {}): any => ({
+  author: { bot: false, id: "owner-id" },
+  guildId: null, // DM
+  content: "",
+  reply: vi.fn().mockResolvedValue({ id: "reply-id" }),
+  ...overrides,
+});
+
+describe("OwnerCommandHandler", () => {
+  let mockBanService: BanService;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let handler: OwnerCommandHandler;
+
+  const OWNER_ID = "owner-id";
+
+  beforeEach(() => {
+    mockBanService = {
+      banUser: vi.fn(),
+      banGuild: vi.fn(),
+      unbanUser: vi.fn(),
+      unbanGuild: vi.fn(),
+      ban: vi.fn(),
+      unban: vi.fn(),
+      isUserBanned: vi.fn(),
+      isGuildBanned: vi.fn(),
+      listBans: vi.fn(),
+      getBan: vi.fn(),
+    } as unknown as BanService;
+
+    mockClient = createMockClient();
+    handler = new OwnerCommandHandler(OWNER_ID, mockBanService, mockClient);
+  });
+
+  describe("handleMessage - ガード条件", () => {
+    it("ギルドメッセージは無視する", async () => {
+      const msg = createMockMessage({ guildId: "guild-1" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(false);
+      expect(msg.reply).not.toHaveBeenCalled();
+    });
+
+    it("Owner 以外のユーザーからの DM は無視する", async () => {
+      const msg = createMockMessage({ author: { bot: false, id: "other-user" } });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(false);
+      expect(msg.reply).not.toHaveBeenCalled();
+    });
+
+    it("Bot メッセージは無視する", async () => {
+      const msg = createMockMessage({ author: { bot: true, id: OWNER_ID } });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(false);
+      expect(msg.reply).not.toHaveBeenCalled();
+    });
+
+    it("プレフィックスが一致しないメッセージは無視する", async () => {
+      const msg = createMockMessage({ content: "!guilds" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(false);
+      expect(msg.reply).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("!owner/ban (ユーザー BAN)", () => {
+    it("userId なしで使用法を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/ban" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("使用方法"));
+    });
+
+    it("ユーザー BAN に成功する", async () => {
+      const msg = createMockMessage({ content: "!owner/ban user-1 spamming" });
+      vi.mocked(mockBanService.banUser).mockResolvedValue({
+        success: true,
+        message: "ユーザー user-1 を BAN しました。",
+      });
+
+      const result = await handler.handleMessage(msg);
+
+      expect(result).toBe(true);
+      expect(mockBanService.banUser).toHaveBeenCalledWith("user-1", "spamming", OWNER_ID);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("BAN しました"));
+    });
+
+    it("既に BAN 済みの場合失敗メッセージを返す", async () => {
+      const msg = createMockMessage({ content: "!owner/ban user-1 spam" });
+      vi.mocked(mockBanService.banUser).mockResolvedValue({
+        success: false,
+        message: "既に BAN されています。",
+      });
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("既に BAN"));
+    });
+  });
+
+  describe("!owner/unban (ユーザー BAN 解除)", () => {
+    it("userId なしで使用法を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/unban" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("使用方法"));
+    });
+
+    it("ユーザー BAN 解除に成功する", async () => {
+      const msg = createMockMessage({ content: "!owner/unban user-1" });
+      vi.mocked(mockBanService.unbanUser).mockResolvedValue({
+        success: true,
+        message: "ユーザー user-1 の BAN を解除しました。",
+      });
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(mockBanService.unbanUser).toHaveBeenCalledWith("user-1");
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("解除"));
+    });
+  });
+
+  describe("!owner/ban-guild (サーバー BAN)", () => {
+    it("guildId なしで使用法を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/ban-guild" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("使用方法"));
+    });
+
+    it("サーバー BAN に成功する（サーバー未参加時）", async () => {
+      const msg = createMockMessage({ content: "!owner/ban-guild guild-1 spamming" });
+      vi.mocked(mockBanService.banGuild).mockResolvedValue({
+        success: true,
+        message: "サーバー guild-1 を BAN しました。",
+      });
+
+      const result = await handler.handleMessage(msg);
+
+      expect(result).toBe(true);
+      expect(mockBanService.banGuild).toHaveBeenCalledWith("guild-1", "spamming", OWNER_ID);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("BAN しました"));
+    });
+
+    it("BAN 後に参加中のサーバーから脱退する", async () => {
+      const msg = createMockMessage({ content: "!owner/ban-guild guild-1 spam" });
+      vi.mocked(mockBanService.banGuild).mockResolvedValue({
+        success: true,
+        message: "BAN しました。",
+      });
+      const leaveFn = vi.fn().mockResolvedValue(undefined);
+      mockClient.guilds.cache.set("guild-1", {
+        id: "guild-1",
+        name: "Test Guild",
+        leave: leaveFn,
+      });
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(leaveFn).toHaveBeenCalled();
+    });
+
+    it("既に BAN 済みの場合失敗メッセージを返す", async () => {
+      const msg = createMockMessage({ content: "!owner/ban-guild guild-1 spam" });
+      vi.mocked(mockBanService.banGuild).mockResolvedValue({
+        success: false,
+        message: "既に BAN されています。",
+      });
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("既に BAN"));
+    });
+  });
+
+  describe("!owner/unban-guild (サーバー BAN 解除)", () => {
+    it("guildId なしで使用法を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/unban-guild" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("使用方法"));
+    });
+
+    it("サーバー BAN 解除に成功する", async () => {
+      const msg = createMockMessage({ content: "!owner/unban-guild guild-1" });
+      vi.mocked(mockBanService.unbanGuild).mockResolvedValue({
+        success: true,
+        message: "サーバー guild-1 の BAN を解除しました。",
+      });
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(mockBanService.unbanGuild).toHaveBeenCalledWith("guild-1");
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("解除"));
+    });
+  });
+
+  describe("!owner/leave", () => {
+    it("guildId なしで使用法を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/leave" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("使用方法"));
+    });
+
+    it("参加していないサーバーの場合メッセージを返す", async () => {
+      const msg = createMockMessage({ content: "!owner/leave guild-999" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("参加していません"));
+    });
+
+    it("参加中のサーバーから脱退する", async () => {
+      const msg = createMockMessage({ content: "!owner/leave guild-1" });
+      const leaveFn = vi.fn().mockResolvedValue(undefined);
+      mockClient.guilds.cache.set("guild-1", {
+        id: "guild-1",
+        name: "Test Guild",
+        leave: leaveFn,
+      });
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(leaveFn).toHaveBeenCalled();
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("脱退"));
+    });
+  });
+
+  describe("!owner/list-bans", () => {
+    it("BAN がない場合その旨を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/list-bans" });
+      vi.mocked(mockBanService.listBans).mockResolvedValue([]);
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("ありません"));
+    });
+
+    it("BAN 一覧を整形して返す", async () => {
+      const msg = createMockMessage({ content: "!owner/list-bans" });
+      vi.mocked(mockBanService.listBans).mockResolvedValue([
+        {
+          targetId: "user-1",
+          targetType: "user",
+          reason: "スパム",
+          bannedBy: "owner-1",
+          bannedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          targetId: "guild-1",
+          targetType: "guild",
+          reason: "暴言",
+          bannedBy: "owner-1",
+          bannedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ]);
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("user-1"));
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("guild-1"));
+    });
+  });
+
+  describe("!owner/guilds", () => {
+    it("参加サーバーがない場合その旨を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/guilds" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("どのサーバーにも参加"));
+    });
+
+    it("参加サーバー一覧を返す", async () => {
+      const msg = createMockMessage({ content: "!owner/guilds" });
+      mockClient.guilds.cache.set("guild-1", {
+        id: "guild-1",
+        name: "Test Guild",
+        memberCount: 100,
+      });
+      vi.mocked(mockBanService.listBans).mockResolvedValue([]);
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("Test Guild"));
+    });
+  });
+
+  describe("!owner/help", () => {
+    it("ヘルプテキストを返す", async () => {
+      const msg = createMockMessage({ content: "!owner/help" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("Owner コマンド一覧"));
+    });
+  });
+
+  describe("不明なコマンド", () => {
+    it("エラーメッセージを返す", async () => {
+      const msg = createMockMessage({ content: "!owner/unknown" });
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("不明なコマンド"));
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    it("BanService が例外を投げた場合エラーメッセージを返す", async () => {
+      const msg = createMockMessage({ content: "!owner/ban user-1 spam" });
+      vi.mocked(mockBanService.banUser).mockRejectedValue(new Error("Redis connection failed"));
+
+      const result = await handler.handleMessage(msg);
+      expect(result).toBe(true);
+      expect(msg.reply).toHaveBeenCalledWith(expect.stringContaining("Redis connection failed"));
+    });
+  });
+});

--- a/tests/unit/core/BanService.test.ts
+++ b/tests/unit/core/BanService.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BanEntry, IBanRepository } from "@/core/models/BanEntry";
+import { BanService } from "@/core/services/BanService";
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const createMockRepo = (): IBanRepository => ({
+  addBan: vi.fn(),
+  removeBan: vi.fn(),
+  isBanned: vi.fn(),
+  listBans: vi.fn(),
+  getBan: vi.fn(),
+});
+
+const createBanEntry = (overrides: Partial<BanEntry> = {}): BanEntry => ({
+  targetId: "target-1",
+  targetType: "user",
+  reason: "スパム",
+  bannedBy: "owner-1",
+  bannedAt: "2026-06-12T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("BanService", () => {
+  let mockRepo: IBanRepository;
+  let service: BanService;
+
+  beforeEach(() => {
+    mockRepo = createMockRepo();
+    service = new BanService(mockRepo);
+  });
+
+  describe("ban (汎用)", () => {
+    it("新規 BAN の場合成功を返す", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(false);
+
+      const result = await service.ban("user-1", "user", "スパム", "owner-1");
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("user-1");
+      expect(mockRepo.addBan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetId: "user-1",
+          targetType: "user",
+          reason: "スパム",
+          bannedBy: "owner-1",
+        }),
+      );
+    });
+
+    it("既に BAN 済みの場合失敗を返す", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(true);
+
+      const result = await service.ban("user-1", "user", "スパム", "owner-1");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("既に BAN");
+      expect(mockRepo.addBan).not.toHaveBeenCalled();
+    });
+
+    it("ban された日時が ISO 8601 形式である", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(false);
+
+      await service.ban("user-1", "user", "test", "owner-1");
+
+      expect(mockRepo.addBan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bannedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+        }),
+      );
+    });
+  });
+
+  describe("banUser", () => {
+    it("ユーザー BAN に成功する", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(false);
+
+      const result = await service.banUser("user-1", "スパム", "owner-1");
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("ユーザー");
+      expect(mockRepo.addBan).toHaveBeenCalledWith(
+        expect.objectContaining({ targetId: "user-1", targetType: "user" }),
+      );
+    });
+  });
+
+  describe("banGuild", () => {
+    it("サーバー BAN に成功する", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(false);
+
+      const result = await service.banGuild("guild-1", "スパム", "owner-1");
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("サーバー");
+      expect(mockRepo.addBan).toHaveBeenCalledWith(
+        expect.objectContaining({ targetId: "guild-1", targetType: "guild" }),
+      );
+    });
+  });
+
+  describe("unban (汎用)", () => {
+    it("BAN 済みの場合解除に成功する", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(true);
+
+      const result = await service.unban("user-1", "user");
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("解除");
+      expect(mockRepo.removeBan).toHaveBeenCalledWith("user-1", "user");
+    });
+
+    it("BAN されていない場合失敗を返す", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(false);
+
+      const result = await service.unban("user-1", "user");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("BAN されていません");
+      expect(mockRepo.removeBan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unbanUser / unbanGuild", () => {
+    it("unbanUser が正しく委譲する", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(true);
+
+      await service.unbanUser("user-1");
+
+      expect(mockRepo.removeBan).toHaveBeenCalledWith("user-1", "user");
+    });
+
+    it("unbanGuild が正しく委譲する", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(true);
+
+      await service.unbanGuild("guild-1");
+
+      expect(mockRepo.removeBan).toHaveBeenCalledWith("guild-1", "guild");
+    });
+  });
+
+  describe("isUserBanned", () => {
+    it("BAN されている場合 true を返す", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(true);
+
+      const result = await service.isUserBanned("user-1");
+
+      expect(result).toBe(true);
+      expect(mockRepo.isBanned).toHaveBeenCalledWith("user-1", "user");
+    });
+
+    it("BAN されていない場合 false を返す", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(false);
+
+      const result = await service.isUserBanned("user-1");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isGuildBanned", () => {
+    it("BAN されている場合 true を返す", async () => {
+      vi.mocked(mockRepo.isBanned).mockResolvedValue(true);
+
+      const result = await service.isGuildBanned("guild-1");
+
+      expect(result).toBe(true);
+      expect(mockRepo.isBanned).toHaveBeenCalledWith("guild-1", "guild");
+    });
+  });
+
+  describe("listBans", () => {
+    it("全 BAN エントリを返す", async () => {
+      const entries = [
+        createBanEntry(),
+        createBanEntry({ targetId: "guild-1", targetType: "guild" }),
+      ];
+      vi.mocked(mockRepo.listBans).mockResolvedValue(entries);
+
+      const result = await service.listBans();
+
+      expect(result).toEqual(entries);
+    });
+
+    it("targetType でフィルタする", async () => {
+      const userEntries = [
+        createBanEntry({ targetId: "user-1", targetType: "user" }),
+      ];
+      vi.mocked(mockRepo.listBans).mockResolvedValue(userEntries);
+
+      const result = await service.listBans("user");
+
+      expect(mockRepo.listBans).toHaveBeenCalledWith("user");
+      expect(result).toEqual(userEntries);
+    });
+
+    it("空の配列を返す", async () => {
+      vi.mocked(mockRepo.listBans).mockResolvedValue([]);
+
+      const result = await service.listBans();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getBan", () => {
+    it("BAN 情報を返す", async () => {
+      const entry = createBanEntry();
+      vi.mocked(mockRepo.getBan).mockResolvedValue(entry);
+
+      const result = await service.getBan("user-1", "user");
+
+      expect(result).toEqual(entry);
+      expect(mockRepo.getBan).toHaveBeenCalledWith("user-1", "user");
+    });
+
+    it("BAN されていない場合 null を返す", async () => {
+      vi.mocked(mockRepo.getBan).mockResolvedValue(null);
+
+      const result = await service.getBan("user-999", "user");
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/unit/infrastructure/RedisBanRepository.test.ts
+++ b/tests/unit/infrastructure/RedisBanRepository.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BanEntry } from "@/core/models/BanEntry";
+
+vi.mock("@/db/init", () => ({
+  redis: {
+    sAdd: vi.fn(),
+    sRem: vi.fn(),
+    sIsMember: vi.fn(),
+    sMembers: vi.fn(),
+    set: vi.fn(),
+    get: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { redis } from "@/db/init";
+import { RedisBanRepository } from "@/infrastructure/db/RedisBanRepository";
+
+const makeUserEntry = (overrides: Partial<BanEntry> = {}): BanEntry => ({
+  targetId: "user-1",
+  targetType: "user",
+  reason: "スパム",
+  bannedBy: "owner-1",
+  bannedAt: "2026-06-12T00:00:00.000Z",
+  ...overrides,
+});
+
+const makeGuildEntry = (overrides: Partial<BanEntry> = {}): BanEntry => ({
+  targetId: "guild-1",
+  targetType: "guild",
+  reason: "迷惑",
+  bannedBy: "owner-1",
+  bannedAt: "2026-06-12T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("RedisBanRepository", () => {
+  let repo: RedisBanRepository;
+
+  beforeEach(() => {
+    repo = new RedisBanRepository();
+    vi.clearAllMocks();
+  });
+
+  describe("addBan", () => {
+    it("ユーザー BAN: Set と JSON キーを保存する", async () => {
+      const entry = makeUserEntry();
+
+      await repo.addBan(entry);
+
+      expect(redis.sAdd).toHaveBeenCalledWith("app:ban:list", "user:user-1");
+      expect(redis.set).toHaveBeenCalledWith(
+        "app:ban:user:user-1",
+        JSON.stringify(entry),
+      );
+    });
+
+    it("サーバー BAN: Set と JSON キーを保存する", async () => {
+      const entry = makeGuildEntry();
+
+      await repo.addBan(entry);
+
+      expect(redis.sAdd).toHaveBeenCalledWith("app:ban:list", "guild:guild-1");
+      expect(redis.set).toHaveBeenCalledWith(
+        "app:ban:guild:guild-1",
+        JSON.stringify(entry),
+      );
+    });
+  });
+
+  describe("removeBan", () => {
+    it("ユーザー BAN 解除", async () => {
+      await repo.removeBan("user-1", "user");
+
+      expect(redis.sRem).toHaveBeenCalledWith("app:ban:list", "user:user-1");
+      expect(redis.del).toHaveBeenCalledWith("app:ban:user:user-1");
+    });
+
+    it("サーバー BAN 解除", async () => {
+      await repo.removeBan("guild-1", "guild");
+
+      expect(redis.sRem).toHaveBeenCalledWith("app:ban:list", "guild:guild-1");
+      expect(redis.del).toHaveBeenCalledWith("app:ban:guild:guild-1");
+    });
+  });
+
+  describe("isBanned", () => {
+    it("ユーザー BAN: sIsMember が 1 なら true", async () => {
+      vi.mocked(redis.sIsMember).mockResolvedValue(1);
+
+      const result = await repo.isBanned("user-1", "user");
+
+      expect(result).toBe(true);
+      expect(redis.sIsMember).toHaveBeenCalledWith("app:ban:list", "user:user-1");
+    });
+
+    it("サーバー BAN: sIsMember が 0 なら false", async () => {
+      vi.mocked(redis.sIsMember).mockResolvedValue(0);
+
+      const result = await repo.isBanned("guild-1", "guild");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("listBans", () => {
+    it("全 BAN エントリを返す", async () => {
+      const userEntry = makeUserEntry();
+      const guildEntry = makeGuildEntry();
+      vi.mocked(redis.sMembers).mockResolvedValue(["user:user-1", "guild:guild-1"]);
+      vi.mocked(redis.get)
+        .mockResolvedValueOnce(JSON.stringify(userEntry))
+        .mockResolvedValueOnce(JSON.stringify(guildEntry));
+
+      const result = await repo.listBans();
+
+      expect(result).toHaveLength(2);
+    });
+
+    it("targetType でフィルタして返す", async () => {
+      const userEntry = makeUserEntry();
+      vi.mocked(redis.sMembers).mockResolvedValue(["user:user-1", "guild:guild-1"]);
+      vi.mocked(redis.get).mockResolvedValueOnce(JSON.stringify(userEntry));
+
+      const result = await repo.listBans("user");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].targetType).toBe("user");
+    });
+
+    it("BAN がない場合空の配列を返す", async () => {
+      vi.mocked(redis.sMembers).mockResolvedValue([]);
+
+      const result = await repo.listBans();
+
+      expect(result).toEqual([]);
+    });
+
+    it("JSON パースに失敗したエントリをスキップする", async () => {
+      vi.mocked(redis.sMembers).mockResolvedValue(["user:user-1", "guild:guild-1"]);
+      vi.mocked(redis.get)
+        .mockResolvedValueOnce(JSON.stringify(makeUserEntry()))
+        .mockResolvedValueOnce("invalid-json{{{");
+
+      const result = await repo.listBans();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].targetId).toBe("user-1");
+    });
+  });
+
+  describe("getBan", () => {
+    it("存在するエントリを返す（ユーザー）", async () => {
+      const entry = makeUserEntry();
+      vi.mocked(redis.get).mockResolvedValue(JSON.stringify(entry));
+
+      const result = await repo.getBan("user-1", "user");
+
+      expect(result).toEqual(entry);
+      expect(redis.get).toHaveBeenCalledWith("app:ban:user:user-1");
+    });
+
+    it("存在するエントリを返す（サーバー）", async () => {
+      const entry = makeGuildEntry();
+      vi.mocked(redis.get).mockResolvedValue(JSON.stringify(entry));
+
+      const result = await repo.getBan("guild-1", "guild");
+
+      expect(result).toEqual(entry);
+      expect(redis.get).toHaveBeenCalledWith("app:ban:guild:guild-1");
+    });
+
+    it("存在しない場合 null を返す", async () => {
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const result = await repo.getBan("user-999", "user");
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #426

## 変更内容

Bot 管理者が DM から操作できる BAN・脱退機能を追加。

### 新規コマンド（DM 専用）

| コマンド | 対象 | 動作 |
|---|---|---|
| `!owner/ban <userId> [reason]` | 👤 ユーザー | ユーザーを BAN → Bot が投稿を無視 |
| `!owner/unban <userId>` | 👤 ユーザー | BAN 解除 |
| `!owner/ban-guild <guildId> [reason]` | 🏠 サーバー | サーバー BAN + 脱退 + 再招待不可 |
| `!owner/unban-guild <guildId>` | 🏠 サーバー | サーバー BAN 解除 |
| `!owner/leave <guildId>` | 🏠 サーバー | BAN なしで脱退のみ |
| `!owner/list-bans` | — | BAN 一覧表示 |
| `!owner/guilds` | — | 参加サーバー一覧 |
| `!owner/help` | — | ヘルプ |

### アーキテクチャ

- **Core**: `BanEntry` 型 + `BanService`（純粋ロジック）
- **Infrastructure**: `RedisBanRepository`（Redis 永続化）
- **Adapter**: `OwnerCommandHandler`（DM コマンド処理）
- **Integration**: `MessageHandler` にユーザー BAN チェック、`guildCreate` / `clientReady` にサーバー BAN チェック

### 品質ゲート

- Lint: 0 warnings/errors ✅
- Compile: 0 errors ✅
- Tests: 202 passed / 1 skipped ✅