### PR TITLE
feat: vxTwitter/FxTwitterのメディアURL取得をmedia_extended/media.allに変更

### DIFF
--- a/src/adapters/twitter/FxTwitterAdapter.ts
+++ b/src/adapters/twitter/FxTwitterAdapter.ts
@@ -48,16 +48,16 @@ export class FxTwitterAdapter extends BaseTwitterAdapter implements ITwitterAdap
       quote = this.convertToTweet(fxData.quote, depth + 1);
     }
 
-    // メディアの変換
+    // メディアの変換: media.all を優先して使用（photos/videos を統一的に扱える）
     const media: TweetMedia[] = [];
-    if (fxData.media && fxData.media.photos) {
-      fxData.media.photos.forEach((photo) => {
+    if (fxData.media?.all) {
+      for (const item of fxData.media.all) {
         media.push({
-          url: photo.url,
-          thumbnailUrl: photo.thumbnail_url,
-          type: this.getMediaType(photo.url),
+          url: item.url,
+          thumbnailUrl: item.thumbnail_url || item.url,
+          type: item.type === "video" || item.type === "animated_gif" ? "video" : "photo",
         });
-      });
+      }
     }
 
     return {

--- a/src/adapters/twitter/VxTwitterAdapter.ts
+++ b/src/adapters/twitter/VxTwitterAdapter.ts
@@ -53,17 +53,12 @@ export class VxTwitterAdapter extends BaseTwitterAdapter implements ITwitterAdap
       quote = this.convertToTweet(vxData.qrt, depth + 1);
     }
 
-    // メディアの変換
-    const media: TweetMedia[] = vxData.mediaURLs.map((url, index) => {
-      const type = this.getMediaType(url);
-      const thumbnailUrl = type === "video" ? vxData.media_extended[index]?.thumbnail_url || url : url;
-
-      return {
-        url,
-        thumbnailUrl,
-        type,
-      };
-    });
+    // メディアの変換: media_extended を優先して使用
+    const media: TweetMedia[] = vxData.media_extended.map((extended) => ({
+      url: extended.url,
+      thumbnailUrl: extended.thumbnail_url || extended.url,
+      type: extended.type === "video" ? "video" : "photo",
+    }));
 
     return {
       url: vxData.tweetURL,

--- a/src/fxtwitter/fxtwitter.ts
+++ b/src/fxtwitter/fxtwitter.ts
@@ -36,14 +36,37 @@ export interface Author {
 }
 
 export interface Media {
+  all: MediaItem[];
   photos: Photo[];
+  videos: Video[];
+}
+
+export interface MediaItem {
+  type: string;
+  id: string;
+  url: string;
+  thumbnail_url?: string;
+  width?: number;
+  height?: number;
+  altText?: string;
 }
 
 export interface Photo {
   type: string;
-  thumbnail_url: string;
+  id: string;
   url: string;
   width: number;
   height: number;
-  altText: string;
+  altText?: string;
+}
+
+export interface Video {
+  id: string;
+  url: string;
+  thumbnail_url: string;
+  duration: number;
+  width: number;
+  height: number;
+  format: string;
+  type: string;
 }

--- a/src/vxtwitter/vxtwitter.ts
+++ b/src/vxtwitter/vxtwitter.ts
@@ -20,10 +20,15 @@ export interface VxTwitter {
   user_screen_name: string;
 }
 
-interface MediaExtended {
+export interface MediaExtended {
   altText: string | null;
-  size: object[];
+  size: MediaSize;
   thumbnail_url: string;
   type: string;
   url: string;
+}
+
+export interface MediaSize {
+  height: number;
+  width: number;
 }

--- a/tests/unit/adapters/twitter/FxTwitterAdapter.test.ts
+++ b/tests/unit/adapters/twitter/FxTwitterAdapter.test.ts
@@ -7,7 +7,9 @@ import type {
   Tweet as FxTweet,
   Author,
   Media,
+  MediaItem,
   Photo,
+  Video,
 } from "@/fxtwitter/fxtwitter";
 import { FxTwitterAdapter } from "@/adapters/twitter/FxTwitterAdapter";
 
@@ -48,17 +50,20 @@ const createFxTweet = (overrides: Partial<FxTweet> = {}): FxTweet => ({
   ...overrides,
 });
 
-const createFxPhoto = (overrides: Partial<Photo> = {}): Photo => ({
+const createFxMediaItem = (overrides: Partial<MediaItem> = {}): MediaItem => ({
   type: "photo",
-  thumbnail_url: mediaUrl("photo_thumb.jpg"),
+  id: "12345",
   url: mediaUrl("photo.jpg"),
   width: 1920,
   height: 1080,
-  altText: "",
   ...overrides,
 });
 
-const createFxMedia = (photos: Photo[] = []): Media => ({ photos });
+const createFxMedia = (items: MediaItem[] = []): Media => ({
+  all: items,
+  photos: items.filter((m) => m.type === "photo") as Photo[],
+  videos: items.filter((m) => m.type === "video") as Video[],
+});
 
 const createFxResponse = (tweet: FxTweet): FXTwitter => ({
   code: 200,
@@ -120,7 +125,7 @@ describe("FxTwitterAdapter", () => {
 
     it("画像メディアを含むツイートを変換できる", async () => {
       const tweet = createFxTweet({
-        media: createFxMedia([createFxPhoto()]),
+        media: createFxMedia([createFxMediaItem()]),
       });
       mockApi.getPostInformation.mockResolvedValue(createFxResponse(tweet));
 
@@ -129,16 +134,14 @@ describe("FxTwitterAdapter", () => {
       expect(result?.media).toHaveLength(1);
       expect(result?.media[0].type).toBe("photo");
       expect(result?.media[0].url).toBe(mediaUrl("photo.jpg"));
-      expect(result?.media[0].thumbnailUrl).toBe(
-        mediaUrl("photo_thumb.jpg"),
-      );
+      expect(result?.media[0].thumbnailUrl).toBe(mediaUrl("photo.jpg"));
     });
 
     it("複数の画像メディアを変換できる", async () => {
       const tweet = createFxTweet({
         media: createFxMedia([
-          createFxPhoto({ url: mediaUrl("photo1.jpg") }),
-          createFxPhoto({ url: mediaUrl("photo2.jpg") }),
+          createFxMediaItem({ url: mediaUrl("photo1.jpg") }),
+          createFxMediaItem({ url: mediaUrl("photo2.jpg") }),
         ]),
       });
       mockApi.getPostInformation.mockResolvedValue(createFxResponse(tweet));
@@ -146,6 +149,26 @@ describe("FxTwitterAdapter", () => {
       const result = await adapter.fetchTweet("https://x.com/user/status/123");
 
       expect(result?.media).toHaveLength(2);
+    });
+
+    it("動画メディアを含むツイートを変換できる", async () => {
+      const tweet = createFxTweet({
+        media: createFxMedia([
+          createFxMediaItem({
+            type: "video",
+            url: mediaUrl("video.mp4"),
+            thumbnail_url: mediaUrl("thumb.jpg"),
+          }),
+        ]),
+      });
+      mockApi.getPostInformation.mockResolvedValue(createFxResponse(tweet));
+
+      const result = await adapter.fetchTweet("https://x.com/user/status/123");
+
+      expect(result?.media).toHaveLength(1);
+      expect(result?.media[0].type).toBe("video");
+      expect(result?.media[0].url).toBe(mediaUrl("video.mp4"));
+      expect(result?.media[0].thumbnailUrl).toBe(mediaUrl("thumb.jpg"));
     });
 
     it("メディアがない場合 media は空配列になる", async () => {

--- a/tests/unit/adapters/twitter/VxTwitterAdapter.test.ts
+++ b/tests/unit/adapters/twitter/VxTwitterAdapter.test.ts
@@ -3,7 +3,7 @@ import { mediaUrl } from "../../../fixtures/testMediaUrl";
 
 import type { VxTwitterApi } from "@/vxtwitter/api";
 import { VxTwitterServerError } from "@/vxtwitter/api";
-import type { VxTwitter } from "@/vxtwitter/vxtwitter";
+import type { VxTwitter, MediaSize } from "@/vxtwitter/vxtwitter";
 import { VxTwitterAdapter } from "@/adapters/twitter/VxTwitterAdapter";
 
 vi.mock("@/utils/logger", () => ({
@@ -89,9 +89,9 @@ describe("VxTwitterAdapter", () => {
         media_extended: [
           {
             altText: null,
-            size: [],
+            size: { height: 900, width: 1200 },
             thumbnail_url: mediaUrl("photo.jpg"),
-            type: "photo",
+            type: "image",
             url: mediaUrl("photo.jpg"),
           },
         ],
@@ -111,7 +111,7 @@ describe("VxTwitterAdapter", () => {
         media_extended: [
           {
             altText: null,
-            size: [],
+            size: { height: 720, width: 960 },
             thumbnail_url: mediaUrl("thumb.jpg"),
             type: "video",
             url: mediaUrl("video.mp4"),


### PR DESCRIPTION
## 変更内容

Issue #119 対応。vxTwitter/FxTwitter のメディアURL取得方法を改善しました。

### VxTwitter
- `mediaURLs` ではなく `media_extended` を直接参照するように変更
- APIから返ってくる type/vurl/thumbnail_url をそのまま利用
- 実際のAPIレスポンスに合わせて `MediaExtended.size` の型を修正

### FxTwitter
- `media.photos` だけでなく `media.all` から全てのメディアを統一的に取得
- `MediaItem` / `Video` 型を新規追加し、動画メディアに対応
- 画像・動画・animated_gif を適切に区別して処理

### テスト
- VxTwitterAdapter/FxTwitterAdapter のテストを更新
- 動画メディアの変換テストを追加

## 動作確認
- ✅ Lint (oxlint): 0 errors, 0 warnings
- ✅ Compile (tsc --noEmit): 成功
- ✅ Build: 成功
- ✅ Unit tests: 170/170 passed
- ✅ Integration tests: 16/16 passed