### PR TITLE
fix: testsディレクトリに対してoxlintを適用

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,15 +4,7 @@
     "node": true,
     "es2024": true
   },
-  "ignorePatterns": [
-    "dist/**",
-    "coverage/**",
-    "node_modules/**",
-    "*.config.*",
-    "*.mjs",
-    "dashboard/**",
-    "packages/**"
-  ],
+  "ignorePatterns": ["dist/**", "coverage/**", "node_modules/**", "*.config.*", "*.mjs", "dashboard/**", "packages/**"],
   "plugins": ["typescript"],
   "rules": {
     "no-unused-vars": "warn",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,8 +11,7 @@
     "*.config.*",
     "*.mjs",
     "dashboard/**",
-    "packages/**",
-    "tests/**"
+    "packages/**"
   ],
   "plugins": ["typescript"],
   "rules": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,11 @@ const adapter = TwitterAdapter.createDefault(); // ← 内部で Vx/Fx を compo
 
 以下のゲートをすべて通過した状態でなければコミット・マージしてはならない。
 
-| ゲート      | コマンド                              | 内容                                                                          |
-| ----------- | ------------------------------------- | ----------------------------------------------------------------------------- |
+| ゲート      | コマンド                              | 内容                                                                                          |
+| ----------- | ------------------------------------- | --------------------------------------------------------------------------------------------- |
 | **Lint**    | `npm run lint` (oxlint)               | `src/` および `tests/` 以下の全 TypeScript を oxlint でチェック。警告・エラーともにゼロ必須。 |
-| **Compile** | `npm run compile:test` (tsc --noEmit) | TypeScript コンパイルエラーゼロ。パスエイリアス `@/` の解決も含む。           |
-| **Build**   | `npm run build`                       | 本番ビルドが正常に完了すること（clean → shared ビルド → tsc → tsc-alias）。   |
+| **Compile** | `npm run compile:test` (tsc --noEmit) | TypeScript コンパイルエラーゼロ。パスエイリアス `@/` の解決も含む。                           |
+| **Build**   | `npm run build`                       | 本番ビルドが正常に完了すること（clean → shared ビルド → tsc → tsc-alias）。                   |
 
 実装・変更を行ったら、作業完了前に必ず `npm run lint` (`oxlint src/ tests/`) と `npm run compile:test` (`tsc --noEmit`) を実行し、通過を確認する。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,11 +88,11 @@ const adapter = TwitterAdapter.createDefault(); // ← 内部で Vx/Fx を compo
 
 | ゲート      | コマンド                              | 内容                                                                          |
 | ----------- | ------------------------------------- | ----------------------------------------------------------------------------- |
-| **Lint**    | `npm run lint` (oxlint)               | `src/` 以下の全 TypeScript を oxlint でチェック。警告・エラーともにゼロ必須。 |
+| **Lint**    | `npm run lint` (oxlint)               | `src/` および `tests/` 以下の全 TypeScript を oxlint でチェック。警告・エラーともにゼロ必須。 |
 | **Compile** | `npm run compile:test` (tsc --noEmit) | TypeScript コンパイルエラーゼロ。パスエイリアス `@/` の解決も含む。           |
 | **Build**   | `npm run build`                       | 本番ビルドが正常に完了すること（clean → shared ビルド → tsc → tsc-alias）。   |
 
-実装・変更を行ったら、作業完了前に必ず `npm run lint` (`oxlint src/`) と `npm run compile:test` (`tsc --noEmit`) を実行し、通過を確認する。
+実装・変更を行ったら、作業完了前に必ず `npm run lint` (`oxlint src/ tests/`) と `npm run compile:test` (`tsc --noEmit`) を実行し、通過を確認する。
 
 ### コミット前の未使用import確認
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:e2e": "vitest run tests/e2e",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
-    "lint": "oxlint src/",
+    "lint": "oxlint src/ tests/",
     "format": "oxfmt src/"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,27 @@
 {
   "name": "discord-twitter-embed-rx",
   "version": "2.3.0",
-  "description": "",
-  "type": "module",
-  "main": "index.js",
   "private": true,
+  "description": "",
+  "keywords": [
+    "discord",
+    "twitter"
+  ],
+  "homepage": "https://github.com/t1nyb0x/discord-twitter-embed-rx#readme",
+  "bugs": {
+    "url": "https://github.com/t1nyb0x/discord-twitter-embed-rx/issues"
+  },
+  "license": "MIT",
+  "author": "t1nyb0x",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/t1nyb0x/discord-twitter-embed-rx.git"
+  },
   "workspaces": [
     "packages/*"
   ],
+  "type": "module",
+  "main": "index.js",
   "scripts": {
     "start": "node --env-file=.env dist/index.js",
     "start:docker": "node ./dist/index.js",
@@ -26,25 +40,18 @@
     "lint": "oxlint src/ tests/",
     "format": "oxfmt src/"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
+  "dependencies": {
+    "@discordjs/builders": "^1.9.0",
+    "@hono/node-server": "^2.0.4",
+    "@twitterrx/shared": "*",
+    "chalk": "^5.3.0",
+    "discord.js": "^14.26.3",
+    "hono": "^4.12.25",
+    "js-yaml": "^4.1.0",
+    "redis": "^5.7.0",
+    "winston": "^3.17.0",
+    "winston-daily-rotate-file": "^5.0.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/t1nyb0x/discord-twitter-embed-rx.git"
-  },
-  "keywords": [
-    "discord",
-    "twitter"
-  ],
-  "author": "t1nyb0x",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/t1nyb0x/discord-twitter-embed-rx/issues"
-  },
-  "homepage": "https://github.com/t1nyb0x/discord-twitter-embed-rx#readme",
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",
@@ -60,16 +67,9 @@
     "typescript": "^6.0.0",
     "vitest": "^4.0.13"
   },
-  "dependencies": {
-    "@discordjs/builders": "^1.9.0",
-    "@hono/node-server": "^2.0.4",
-    "@twitterrx/shared": "*",
-    "chalk": "^5.3.0",
-    "discord.js": "^14.26.3",
-    "hono": "^4.12.25",
-    "js-yaml": "^4.1.0",
-    "redis": "^5.7.0",
-    "winston": "^3.17.0",
-    "winston-daily-rotate-file": "^5.0.0"
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   }
 }

--- a/tests/e2e/channel-config.test.ts
+++ b/tests/e2e/channel-config.test.ts
@@ -25,7 +25,7 @@ describe("E2E: チャンネル設定機能", () => {
       // Repository と Service を初期化
       configRepository = new RedisChannelConfigRepository();
       configService = new ChannelConfigService(configRepository);
-    } catch (err) {
+    } catch {
       console.warn("[E2E] Skipping tests: Redis is not available");
       redisAvailable = false;
     }

--- a/tests/unit/adapters/discord/OwnerCommandHandler.test.ts
+++ b/tests/unit/adapters/discord/OwnerCommandHandler.test.ts
@@ -1,11 +1,10 @@
-/* oxlint-disable typescript-eslint/no-explicit-any */
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/utils/logger", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+import type { Message } from "discord.js";
 import { OwnerCommandHandler } from "@/adapters/discord/OwnerCommandHandler";
 import { BanService } from "@/core/services/BanService";
 
@@ -28,26 +27,39 @@ class MockCollection<K, V> extends Map<K, V> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createMockClient = (): any => ({
+interface MockGuild {
+  id: string;
+  name: string;
+  memberCount?: number;
+  leave: ReturnType<typeof vi.fn>;
+}
+
+interface MockClient {
+  user: { id: string };
+  guilds: {
+    cache: MockCollection<string, MockGuild>;
+  };
+}
+
+const createMockClient = (): MockClient => ({
   user: { id: "bot-id" },
   guilds: {
-    cache: new MockCollection<string, any>(),
+    cache: new MockCollection<string, MockGuild>(),
   },
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createMockMessage = (overrides: Record<string, unknown> = {}): any => ({
-  author: { bot: false, id: "owner-id" },
-  guildId: null, // DM
-  content: "",
-  reply: vi.fn().mockResolvedValue({ id: "reply-id" }),
-  ...overrides,
-});
+const createMockMessage = (overrides: Record<string, unknown> = {}): Message<boolean> =>
+  ({
+    author: { bot: false, id: "owner-id" },
+    guildId: null, // DM
+    content: "",
+    reply: vi.fn().mockResolvedValue({ id: "reply-id" }),
+    ...overrides,
+  }) as unknown as Message<boolean>;
 
 describe("OwnerCommandHandler", () => {
   let mockBanService: BanService;
-  let mockClient: ReturnType<typeof createMockClient>;
+  let mockClient: MockClient;
   let handler: OwnerCommandHandler;
 
   const OWNER_ID = "owner-id";
@@ -67,7 +79,11 @@ describe("OwnerCommandHandler", () => {
     } as unknown as BanService;
 
     mockClient = createMockClient();
-    handler = new OwnerCommandHandler(OWNER_ID, mockBanService, mockClient);
+    handler = new OwnerCommandHandler(
+      OWNER_ID,
+      mockBanService,
+      mockClient as unknown as ConstructorParameters<typeof OwnerCommandHandler>[2],
+    );
   });
 
   describe("handleMessage - ガード条件", () => {
@@ -313,6 +329,7 @@ describe("OwnerCommandHandler", () => {
         id: "guild-1",
         name: "Test Guild",
         memberCount: 100,
+        leave: vi.fn(),
       });
       vi.mocked(mockBanService.listBans).mockResolvedValue([]);
 

--- a/tests/unit/adapters/discord/OwnerCommandHandler.test.ts
+++ b/tests/unit/adapters/discord/OwnerCommandHandler.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable typescript-eslint/no-explicit-any */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/utils/logger", () => ({

--- a/tests/unit/infrastructure/VideoDownloader.test.ts
+++ b/tests/unit/infrastructure/VideoDownloader.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable typescript-eslint/no-explicit-any */
+
 import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mediaUrl } from "../../fixtures/testMediaUrl";

--- a/tests/unit/infrastructure/VideoDownloader.test.ts
+++ b/tests/unit/infrastructure/VideoDownloader.test.ts
@@ -1,6 +1,5 @@
-/* oxlint-disable typescript-eslint/no-explicit-any */
-
 import { EventEmitter } from "node:events";
+import type { IncomingMessage, ClientRequest } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mediaUrl } from "../../fixtures/testMediaUrl";
 
@@ -11,7 +10,7 @@ vi.mock("node:https", () => ({ get: vi.fn() }));
 vi.mock("node:http", () => ({ get: vi.fn() }));
 
 // モック後にインポート
-import { createWriteStream } from "node:fs";
+import { createWriteStream, type WriteStream } from "node:fs";
 import * as httpsModule from "node:https";
 import * as httpModule from "node:http";
 import { VideoDownloader } from "@/infrastructure/http/VideoDownloader";
@@ -22,18 +21,38 @@ vi.mock("@/utils/logger", () => ({
 
 /** 書き込みストリームのモックを生成 */
 const createMockWriteStream = () => {
-  const stream = new EventEmitter() as ReturnType<typeof createWriteStream>;
-  (stream as any).close = vi.fn(); // eslint-disable-line @typescript-eslint/no-explicit-any
+  const stream = Object.assign(new EventEmitter() as EventEmitter, {
+    close: vi.fn().mockReturnThis(),
+  }) as unknown as WriteStream;
   return stream;
 };
 
 /** HTTP レスポンスのモックを生成 */
 const createMockResponse = (statusCode: number) => {
-  const response = new EventEmitter() as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  response.statusCode = statusCode;
-  response.resume = vi.fn();
-  response.pipe = vi.fn();
+  const response = Object.assign(new EventEmitter() as EventEmitter, {
+    statusCode,
+    resume: vi.fn(),
+    pipe: vi.fn(),
+  }) as unknown as IncomingMessage;
   return response;
+};
+
+/** http.get / https.get のモック実装をセットアップ */
+const setupHttpGetMock = (
+  mockResponse: IncomingMessage,
+  mockRequest?: EventEmitter,
+) => {
+  const req = mockRequest ?? new EventEmitter();
+  (vi.mocked(httpModule.get) as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (_url: unknown, _optionsOrCb: unknown, maybeCb?: unknown) => {
+      const callback = maybeCb ?? _optionsOrCb;
+      if (typeof callback === "function") {
+        callback(mockResponse);
+      }
+      return req;
+    },
+  );
+  return req as unknown as ClientRequest;
 };
 
 describe("VideoDownloader", () => {
@@ -50,18 +69,11 @@ describe("VideoDownloader", () => {
       vi.mocked(createWriteStream).mockReturnValue(mockWriteStream);
 
       const mockResponse = createMockResponse(200);
-      mockResponse.pipe.mockImplementation(() => {
+      mockResponse.pipe = vi.fn().mockImplementation(() => {
         process.nextTick(() => mockWriteStream.emit("finish"));
       });
 
-      const mockRequest = new EventEmitter();
-      vi.mocked(httpModule.get as any).mockImplementation(
-        (_url: any, callback: any) => {
-          // eslint-disable-line @typescript-eslint/no-explicit-any
-          callback(mockResponse);
-          return mockRequest;
-        },
-      );
+      setupHttpGetMock(mockResponse);
 
       await expect(
         downloader.download(mediaUrl("video.mp4"), "/tmp/test.mp4"),
@@ -69,7 +81,7 @@ describe("VideoDownloader", () => {
 
       expect(createWriteStream).toHaveBeenCalledWith("/tmp/test.mp4");
       expect(mockResponse.pipe).toHaveBeenCalledWith(mockWriteStream);
-      expect((mockWriteStream as any).close).toHaveBeenCalled(); // eslint-disable-line @typescript-eslint/no-explicit-any
+      expect(mockWriteStream.close).toHaveBeenCalled();
     });
 
     it("HTTP URL をダウンロードできる", async () => {
@@ -77,18 +89,11 @@ describe("VideoDownloader", () => {
       vi.mocked(createWriteStream).mockReturnValue(mockWriteStream);
 
       const mockResponse = createMockResponse(200);
-      mockResponse.pipe.mockImplementation(() => {
+      mockResponse.pipe = vi.fn().mockImplementation(() => {
         process.nextTick(() => mockWriteStream.emit("finish"));
       });
 
-      const mockRequest = new EventEmitter();
-      vi.mocked(httpModule.get as any).mockImplementation(
-        (_url: any, callback: any) => {
-          // eslint-disable-line @typescript-eslint/no-explicit-any
-          callback(mockResponse);
-          return mockRequest;
-        },
-      );
+      setupHttpGetMock(mockResponse);
 
       await expect(
         downloader.download(mediaUrl("video.mp4"), "/tmp/test.mp4"),
@@ -100,15 +105,8 @@ describe("VideoDownloader", () => {
 
     it("HTTP 200 以外のレスポンス（例: 404）は reject する", async () => {
       const mockResponse = createMockResponse(404);
-      const mockRequest = new EventEmitter();
 
-      vi.mocked(httpModule.get as any).mockImplementation(
-        (_url: any, callback: any) => {
-          // eslint-disable-line @typescript-eslint/no-explicit-any
-          callback(mockResponse);
-          return mockRequest;
-        },
-      );
+      setupHttpGetMock(mockResponse);
 
       await expect(
         downloader.download(mediaUrl("video.mp4"), "/tmp/test.mp4"),
@@ -119,7 +117,9 @@ describe("VideoDownloader", () => {
 
     it("リクエストエラーが発生した場合 reject する", async () => {
       const mockRequest = new EventEmitter();
-      vi.mocked(httpModule.get as any).mockImplementation(() => mockRequest); // eslint-disable-line @typescript-eslint/no-explicit-any
+      (vi.mocked(httpModule.get) as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        () => mockRequest,
+      );
 
       const downloadPromise = downloader.download(
         mediaUrl("video.mp4"),
@@ -135,26 +135,19 @@ describe("VideoDownloader", () => {
       vi.mocked(createWriteStream).mockReturnValue(mockWriteStream);
 
       const mockResponse = createMockResponse(200);
-      mockResponse.pipe.mockImplementation(() => {
+      mockResponse.pipe = vi.fn().mockImplementation(() => {
         process.nextTick(() =>
           mockWriteStream.emit("error", new Error("disk full")),
         );
       });
 
-      const mockRequest = new EventEmitter();
-      vi.mocked(httpModule.get as any).mockImplementation(
-        (_url: any, callback: any) => {
-          // eslint-disable-line @typescript-eslint/no-explicit-any
-          callback(mockResponse);
-          return mockRequest;
-        },
-      );
+      setupHttpGetMock(mockResponse);
 
       await expect(
         downloader.download(mediaUrl("video.mp4"), "/tmp/test.mp4"),
       ).rejects.toThrow("disk full");
 
-      expect((mockWriteStream as any).close).toHaveBeenCalled(); // eslint-disable-line @typescript-eslint/no-explicit-any
+      expect(mockWriteStream.close).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## 変更内容

- `.oxlintrc.json` の `ignorePatterns` から `tests/**` を削除
- `package.json` の lint スクリプトを `oxlint src/ tests/` に変更
- テストファイル内の事前存在 lint 警告を修正（未使用 catch 変数の削除、no-explicit-any のファイルレベル許可）
- AGENTS.md の品質ゲート説明を更新

closes #483