### PR TITLE
fix: suppressEmbedsを遅らせた

### DIFF
--- a/src/adapters/discord/MessageHandler.ts
+++ b/src/adapters/discord/MessageHandler.ts
@@ -123,9 +123,6 @@ export class MessageHandler {
       messageId: message.id,
     });
 
-    // 元メッセージの埋め込みを抑制
-    await message.suppressEmbeds(true);
-
     // 通常URLの処理
     await this.processUrls(client, message, normal, false);
 
@@ -138,6 +135,9 @@ export class MessageHandler {
       totalUrls: urls.length,
       duration: `${duration}ms`,
     });
+
+    // 元メッセージの埋め込みを抑制
+    await message.suppressEmbeds(true);
   }
 
   /**


### PR DESCRIPTION
Why
- #63 の軽減のため。完全解決とはならないことに留意。

(補足)  
Discordの展開速度よりvx/fx APIの展開速度が早ければ残り続けるが、そうなることは少ないと見ていいので、実用上問題ないと考えられます。