### PR TITLE
fix(discord): Embed内のメンション装飾を修正

### DIFF
--- a/src/adapters/discord/EmbedBuilder.ts
+++ b/src/adapters/discord/EmbedBuilder.ts
@@ -57,7 +57,7 @@ export class DiscordEmbedBuilder {
     // 説明文の作成（引用ツイート情報を含む）
     let description = this.convertMentionsToLinks(tweet.text);
     if (tweet.quote) {
-      const quoteAuthorLink = `[@${tweet.quote.author.id}](https://x.com/${tweet.quote.author.id})`;
+      const quoteAuthorLink = this.createMentionLink(tweet.quote.author.id);
       const quoteTextWithLinks = this.convertMentionsToLinks(tweet.quote.text);
       const quoteText = this.quotePrefix + quoteAuthorLink + " " + quoteTextWithLinks;
       const quoteUrl = "(" + tweet.quote.url + ")";
@@ -100,13 +100,22 @@ export class DiscordEmbedBuilder {
     });
 
     // @メンションをマークダウンリンクに変換（連続する@の最後のみ変換、全角@にも対応）
-    const transformed = textWithPlaceholders.replace(
-      /([@＠]*)[@＠]([A-Za-z0-9_]{1,15})\b/g,
-      "$1[@$2](https://x.com/$2)"
-    );
+    const transformed = textWithPlaceholders.replace(/([@＠]*)[@＠]([A-Za-z0-9_]{1,15})\b/g, (_, prefix, username) => {
+      return prefix + this.createMentionLink(username);
+    });
 
     // プレースホルダーを元のURLに戻す
     return transformed.replace(/__URL_PLACEHOLDER_(\d+)__/g, (_, index) => urls[parseInt(index)]);
+  }
+
+  /**
+   * ユーザー名のMarkdown装飾を無効化したリンクを作成
+   * @param username Xのユーザー名
+   * @returns ユーザーページへのMarkdownリンク
+   */
+  private createMentionLink(username: string): string {
+    const escapedUsername = username.replaceAll("_", "\\_");
+    return `[@${escapedUsername}](https://x.com/${username})`;
   }
 
   /**

--- a/tests/unit/adapters/discord/EmbedBuilder.test.ts
+++ b/tests/unit/adapters/discord/EmbedBuilder.test.ts
@@ -59,7 +59,7 @@ describe("DiscordEmbedBuilder", () => {
       const embedData = embed.toJSON();
 
       expect(embedData.description).toContain("QT:");
-      expect(embedData.description).toContain("[@quoted_user](https://x.com/quoted_user)");
+      expect(embedData.description).toContain("[@quoted\\_user](https://x.com/quoted_user)");
       expect(embedData.description).toContain("Original tweet");
       expect(embedData.description).toContain(MOCK_TWEET_WITH_QUOTE.quote?.url);
     });
@@ -113,8 +113,8 @@ describe("DiscordEmbedBuilder", () => {
       const embed = embeds[0];
       const embedData = embed.toJSON();
 
-      expect(embedData.description).toContain("[@user_name](https://x.com/user_name)");
-      expect(embedData.description).toContain("[@another_user](https://x.com/another_user)");
+      expect(embedData.description).toContain("[@user\\_name](https://x.com/user_name)");
+      expect(embedData.description).toContain("[@another\\_user](https://x.com/another_user)");
     });
 
     it("URL内の@は変換されない", () => {
@@ -135,8 +135,28 @@ describe("DiscordEmbedBuilder", () => {
       const embedData = embed.toJSON();
 
       expect(embedData.description).toContain("[@someone](https://x.com/someone)");
-      expect(embedData.description).toContain("[@quoted_user](https://x.com/quoted_user)");
+      expect(embedData.description).toContain("[@quoted\\_user](https://x.com/quoted_user)");
       expect(embedData.description).toContain("[@friend](https://x.com/friend)");
+    });
+
+    it("アンダースコアを含むメンションのリンク表示が装飾されない", () => {
+      const tweet = createMockTweet({
+        text: "Hello @_user_name_",
+        quote: createMockTweet({
+          author: {
+            id: "_quoted_user_",
+            name: "Quoted User",
+            url: "https://x.com/_quoted_user_",
+            iconUrl: "https://example.com/icon.jpg",
+          },
+        }),
+      });
+      const embeds = builder.build(tweet);
+
+      const description = embeds[0].toJSON().description;
+
+      expect(description).toContain("[@\\_user\\_name\\_](https://x.com/_user_name_)");
+      expect(description).toContain("[@\\_quoted\\_user\\_](https://x.com/_quoted_user_)");
     });
 
     it("4096文字を超える説明文は省略される", () => {


### PR DESCRIPTION
## 概要

Embed内のXユーザー名にアンダースコアが含まれる場合、Discord Markdownによって意図しない装飾が適用される問題を修正します。

Fixes #518

## 原因

メンションをMarkdownリンクへ変換する際、ユーザー名をリンクの表示文字列へ未エスケープで埋め込んでいました。そのため、`@_hoge_` などのユーザー名が斜体として解釈されていました。

## 変更内容

- Markdownリンクの表示文字列に含まれるアンダースコアをエスケープ
- リンク先URLのユーザー名は変更せず維持
- 通常本文と引用ツイートのユーザーリンクへ共通処理を適用
- アンダースコアを含むユーザー名の回帰テストを追加

## 影響

アンダースコアを含むユーザー名が装飾されずに表示されます。リンク先やアンダースコアを含まないユーザー名の動作は変わりません。

## 検証

- `npm run lint`
- `npm run compile:test`
- `npm test -- --run` (`244 passed / 1 skipped`)
- `npm run build`
- `git diff --check`
