### PR TITLE
feat: 投票付きポストのEmbed表示に対応

### DIFF
--- a/docs/issue-541-poll-support.md
+++ b/docs/issue-541-poll-support.md
@@ -1,0 +1,175 @@
+# Issue #541: 投票表示対応の設計
+
+- Issue: https://github.com/rx-twitter/rx-twitter/issues/541
+- 対象ブランチ: `feat/issue-541-poll-support`
+- Status: Implemented
+
+## 背景
+
+現在の Bot は vxTwitter / FxTwitter のレスポンスに含まれる投票情報を Core の
+`Tweet` モデルへ変換していないため、Discord Embed に投票の選択肢が表示されない。
+
+Issue の再現用ポストを確認すると、API ごとのレスポンスは次のように異なる。
+
+- vxTwitter は `pollData.options` に選択肢名、得票数、得票率を返す。
+- FxTwitter は `poll.choices` に同等の情報を返すが、同名の選択肢を重複排除する。
+- 再現用ポストでは、vxTwitter は同名の 2 選択肢を保持し、FxTwitter は 1 選択肢だけを返す。
+
+Bot のデフォルト構成では VxTwitterAdapter がプライマリ、FxTwitterAdapter が
+フォールバックである。
+
+## 目的
+
+- 通常の投票付きポストで、選択肢、得票数、得票率を Discord Embed に表示する。
+- 同名の選択肢を Bot 内で重複排除せず、API が返した順序のまま表示する。
+- 投票のない既存ポストの表示を変更しない。
+- 外部 API の DTO を Core や Discord Adapter に漏らさない。
+
+## スコープ外
+
+- Discord 上から投票する機能
+- 投票終了時刻や残り時間の表示
+- 定期的な再取得による得票結果の更新
+- FxTwitter が上流で重複排除した選択肢の復元
+- 引用ポスト内の投票表示
+
+FxTwitter のレスポンスだけでは、重複排除された選択肢の名前、個数、順序を復元できない。
+そのため、VxTwitter から取得できた場合は正確な選択肢を表示し、FxTwitter への
+フォールバック時は FxTwitter が返した内容を best-effort で表示する。
+
+## ドメインモデル
+
+`src/core/models/Tweet.ts` に API 非依存の投票モデルを追加する。
+
+```typescript
+export interface Tweet {
+  // 既存フィールド
+  poll?: TweetPoll;
+}
+
+export interface TweetPoll {
+  options: TweetPollOption[];
+}
+
+export interface TweetPollOption {
+  label: string;
+  votes: number;
+  percentage: number;
+}
+```
+
+`poll` は投票が存在し、有効な選択肢が 1 件以上ある場合だけ設定する。`options` は配列の
+順序と重複を保持する。終了時刻は vxTwitter から取得できず、プロバイダー間で一貫した
+表示にできないため、今回の共通モデルには含めない。
+
+## API Adapter の変換
+
+### VxTwitterAdapter
+
+`pollData.options` を次のように変換する。
+
+| vxTwitter | Core |
+| --- | --- |
+| `name` | `label` |
+| `votes` | `votes` |
+| `percent` | `percentage` |
+
+VxTwitter の OpenAPI では各フィールドが optional であるため、3 フィールドが揃った
+選択肢だけを有効とする。空配列または有効な選択肢がない場合は `poll` を設定しない。
+変換処理で `Set` などを使わず、同名の選択肢を保持する。
+
+### FxTwitterAdapter
+
+`poll.choices` を次のように変換する。
+
+| FxTwitter | Core |
+| --- | --- |
+| `label` | `label` |
+| `count` | `votes` |
+| `percentage` | `percentage` |
+
+FxTwitter の OpenAPI では各フィールドが必須である。空配列の場合は `poll` を設定しない。
+上流ですでに重複排除された選択肢は復元しない。
+
+### 引用ポスト
+
+既存の再帰変換により引用ポストの `Tweet` にも `poll` は保持される。ただし、現在の
+Embed は引用ポストについて作者、本文、URL だけを表示するため、今回の表示対象は
+トップレベルのポストだけとする。
+
+## Discord Embed
+
+既存の 3 つのメトリクスフィールドの後に、投票がある場合だけ 1 フィールドを追加する。
+
+表示例:
+
+```text
+:bar_chart: poll
+1. 千冬ちゃん — 0 votes (0%)
+2. 千冬ちゃん — 0 votes (0%)
+```
+
+- 行頭に番号を付け、同名の選択肢が複数あることを判別可能にする。
+- 得票数と得票率は API の数値をそのまま表示する。
+- 投票全体を 1 フィールドにまとめ、既存のメディアギャラリー構成を維持する。
+- 複数メディアの場合、投票フィールドは本文と同様に先頭 Embed だけへ設定する。
+- Discord Embed の field value 上限に合わせ、投票フィールドは最大 1,024 文字に
+  切り詰める。超過時は末尾を `...` とする。
+
+## テスト方針
+
+### VxTwitterAdapter
+
+- 投票情報を Core モデルへ変換できる。
+- 同名の選択肢を順序どおり保持する。
+- `pollData` がない場合は `poll` が `undefined` になる。
+- 空の `options` または必須値が欠けた選択肢だけの場合は `poll` が `undefined` になる。
+
+### FxTwitterAdapter
+
+- 投票情報を Core モデルへ変換できる。
+- API が返した選択肢の順序を保持する。
+- `poll` がない場合または `choices` が空の場合は Core の `poll` が `undefined` になる。
+
+### DiscordEmbedBuilder
+
+- 投票フィールドに番号、ラベル、得票数、得票率が表示される。
+- 同名の選択肢が別々の行に表示される。
+- 投票がない場合は既存の 3 フィールドだけが生成される。
+- 複数メディアの場合は先頭 Embed だけに投票フィールドが含まれる。
+- 投票フィールドが 1,024 文字を超えない。
+
+## ADR の要否
+
+追加 ADR は作成しない。
+
+今回の変更は、既存の ADR 0001 で決定済みの「外部 API DTO を Adapter で Bot 内部の
+安定したドメイン契約へ変換する」という責務境界に従うもので、新しいアーキテクチャ上の
+選択や責務変更を伴わないためである。
+
+## 変更ファイル
+
+- `src/core/models/Tweet.ts`
+- `src/adapters/twitter/VxTwitterAdapter.ts`
+- `src/adapters/twitter/FxTwitterAdapter.ts`
+- `src/adapters/discord/EmbedBuilder.ts`
+- `tests/unit/adapters/twitter/VxTwitterAdapter.test.ts`
+- `tests/unit/adapters/twitter/FxTwitterAdapter.test.ts`
+- `tests/unit/adapters/discord/EmbedBuilder.test.ts`
+
+OpenAPI と生成コードには投票フィールドがすでに存在するため、今回の変更対象には含めない。
+
+## 受け入れ条件
+
+- 再現用ポストを VxTwitter 経由で取得したとき、同名の 2 選択肢が Discord Embed に
+  別々の行として表示される。
+- 投票のないポストの Embed JSON が投票対応前と同等である。
+- `npm run lint`、`npm run compile:test`、関連する unit test、`npm run build` が通過する。
+
+## 検証結果
+
+- 全 unit test: 20 files / 258 tests passed
+- `npm run lint`: passed
+- `npm run compile:test`: passed
+- `npm run build`: passed
+- Issue の再現用ポスト: 同名の 2 選択肢を保持し、想定どおりの投票フィールドを生成

--- a/src/adapters/discord/EmbedBuilder.ts
+++ b/src/adapters/discord/EmbedBuilder.ts
@@ -1,6 +1,6 @@
 import { APIEmbedField, EmbedBuilder } from "discord.js";
 
-import { Tweet } from "@/core/models/Tweet";
+import { Tweet, TweetPollOption } from "@/core/models/Tweet";
 
 /**
  * Discord Embed作成を担当
@@ -10,6 +10,7 @@ export class DiscordEmbedBuilder {
   private readonly quotePrefix = "QT: ";
   private readonly br = "\n";
   private readonly maxDescriptionLength = 4096;
+  private readonly maxPollFieldLength = 1024;
 
   /**
    * ツイートからDiscord Embedを作成
@@ -54,6 +55,10 @@ export class DiscordEmbedBuilder {
       )
       .setTimestamp(tweet.timestamp);
 
+    if (tweet.poll && tweet.poll.options.length > 0) {
+      embed.addFields(this.createPollField(tweet.poll.options));
+    }
+
     // 説明文の作成（引用ツイート情報を含む）
     let description = this.convertMentionsToLinks(tweet.text);
     if (tweet.quote) {
@@ -82,6 +87,25 @@ export class DiscordEmbedBuilder {
       inline: true,
       name,
       value: String(count),
+    };
+  }
+
+  /**
+   * 投票フィールドを作成
+   * @param options 投票の選択肢
+   * @returns APIEmbedField
+   */
+  private createPollField(options: TweetPollOption[]): APIEmbedField {
+    const value = options
+      .map((option, index) => {
+        return `${index + 1}. ${option.label} — ${option.votes} votes (${option.percentage}%)`;
+      })
+      .join(this.br);
+
+    return {
+      inline: false,
+      name: ":bar_chart: poll",
+      value: this.truncatePollField(value),
     };
   }
 
@@ -127,5 +151,17 @@ export class DiscordEmbedBuilder {
       return text;
     }
     return text.substring(0, this.maxDescriptionLength - 3) + "...";
+  }
+
+  /**
+   * 投票フィールドを最大長に収める（超過時は末尾を省略）
+   * @param text 投票フィールドの文字列
+   * @returns 切り詰められた投票フィールド
+   */
+  private truncatePollField(text: string): string {
+    if (text.length <= this.maxPollFieldLength) {
+      return text;
+    }
+    return text.substring(0, this.maxPollFieldLength - 3) + "...";
   }
 }

--- a/src/adapters/twitter/FxTwitterAdapter.ts
+++ b/src/adapters/twitter/FxTwitterAdapter.ts
@@ -78,6 +78,17 @@ export class FxTwitterAdapter extends BaseTwitterAdapter implements ITwitterAdap
       }
     }
 
+    const poll =
+      fxData.poll && fxData.poll.choices.length > 0
+        ? {
+            options: fxData.poll.choices.map((choice) => ({
+              label: choice.label,
+              votes: choice.count,
+              percentage: choice.percentage,
+            })),
+          }
+        : undefined;
+
     const author = fxData.author;
     return {
       url: fxData.url,
@@ -85,6 +96,7 @@ export class FxTwitterAdapter extends BaseTwitterAdapter implements ITwitterAdap
       text: fxData.text,
       metrics: this.createMetrics(fxData.replies, fxData.likes, fxData.reposts),
       media,
+      poll,
       quote,
       timestamp: new Date(fxData.created_at),
     };

--- a/src/adapters/twitter/VxTwitterAdapter.ts
+++ b/src/adapters/twitter/VxTwitterAdapter.ts
@@ -71,6 +71,21 @@ export class VxTwitterAdapter extends BaseTwitterAdapter implements ITwitterAdap
             }))
           : [];
 
+    const pollOptions = vxData.pollData?.options?.flatMap((option) => {
+      if (option.name === undefined || option.votes === undefined || option.percent === undefined) {
+        return [];
+      }
+
+      return [
+        {
+          label: option.name,
+          votes: option.votes,
+          percentage: option.percent,
+        },
+      ];
+    });
+    const poll = pollOptions && pollOptions.length > 0 ? { options: pollOptions } : undefined;
+
     return {
       url: vxData.tweetURL,
       author: this.createAuthor(
@@ -82,6 +97,7 @@ export class VxTwitterAdapter extends BaseTwitterAdapter implements ITwitterAdap
       text: vxData.text,
       metrics: this.createMetrics(vxData.replies, vxData.likes, vxData.retweets),
       media,
+      poll,
       quote,
       timestamp: new Date(vxData.date),
     };

--- a/src/core/models/Tweet.ts
+++ b/src/core/models/Tweet.ts
@@ -4,6 +4,7 @@ export interface Tweet {
   text: string;
   metrics: TweetMetrics;
   media: TweetMedia[];
+  poll?: TweetPoll;
   quote?: Tweet;
   timestamp: Date;
 }
@@ -25,4 +26,14 @@ export interface TweetMedia {
   url: string;
   thumbnailUrl: string;
   type: "photo" | "video";
+}
+
+export interface TweetPoll {
+  options: TweetPollOption[];
+}
+
+export interface TweetPollOption {
+  label: string;
+  votes: number;
+  percentage: number;
 }

--- a/tests/unit/adapters/discord/EmbedBuilder.test.ts
+++ b/tests/unit/adapters/discord/EmbedBuilder.test.ts
@@ -52,6 +52,74 @@ describe("DiscordEmbedBuilder", () => {
       expect(embedData.fields?.[2].value).toBe("50");
     });
 
+    it("投票の選択肢を番号、得票数、得票率付きで表示する", () => {
+      const tweet = createMockTweet({
+        poll: {
+          options: [
+            { label: "選択肢A", votes: 3, percentage: 75 },
+            { label: "選択肢B", votes: 1, percentage: 25 },
+          ],
+        },
+      });
+
+      const embedData = builder.build(tweet)[0].toJSON();
+      const pollField = embedData.fields?.[3];
+
+      expect(embedData.fields).toHaveLength(4);
+      expect(pollField).toEqual({
+        inline: false,
+        name: ":bar_chart: poll",
+        value: "1. 選択肢A — 3 votes (75%)\n2. 選択肢B — 1 votes (25%)",
+      });
+    });
+
+    it("同名の投票選択肢を別々の行に表示する", () => {
+      const tweet = createMockTweet({
+        poll: {
+          options: [
+            { label: "千冬ちゃん", votes: 0, percentage: 0 },
+            { label: "千冬ちゃん", votes: 0, percentage: 0 },
+          ],
+        },
+      });
+
+      const pollField = builder.build(tweet)[0].toJSON().fields?.[3];
+
+      expect(pollField?.value).toBe(
+        "1. 千冬ちゃん — 0 votes (0%)\n2. 千冬ちゃん — 0 votes (0%)",
+      );
+    });
+
+    it("複数メディアの場合は先頭Embedだけに投票を表示する", () => {
+      const tweet = createMockTweet({
+        media: [
+          { url: mediaUrl("photo1.jpg"), thumbnailUrl: mediaUrl("photo1.jpg"), type: "photo" },
+          { url: mediaUrl("photo2.jpg"), thumbnailUrl: mediaUrl("photo2.jpg"), type: "photo" },
+        ],
+        poll: {
+          options: [{ label: "選択肢A", votes: 1, percentage: 100 }],
+        },
+      });
+
+      const embeds = builder.build(tweet);
+
+      expect(embeds[0].toJSON().fields?.[3].name).toBe(":bar_chart: poll");
+      expect(embeds[1].toJSON().fields).toBeUndefined();
+    });
+
+    it("投票フィールドを1024文字以内に省略する", () => {
+      const tweet = createMockTweet({
+        poll: {
+          options: [{ label: "長い選択肢".repeat(300), votes: 1, percentage: 100 }],
+        },
+      });
+
+      const pollField = builder.build(tweet)[0].toJSON().fields?.[3];
+
+      expect(pollField?.value).toHaveLength(1024);
+      expect(pollField?.value).toMatch(/\.\.\.$/);
+    });
+
     it("引用ツイートの情報が説明文に含まれる", () => {
       const embeds = builder.build(MOCK_TWEET_WITH_QUOTE);
 

--- a/tests/unit/adapters/twitter/FxTwitterAdapter.test.ts
+++ b/tests/unit/adapters/twitter/FxTwitterAdapter.test.ts
@@ -221,6 +221,54 @@ describe("FxTwitterAdapter", () => {
       expect(result?.metrics.retweets).toBe(50);
     });
 
+    it("投票情報を順序どおりTweetモデルへ変換できる", async () => {
+      const status = createFxStatus({
+        poll: {
+          choices: [
+            { label: "選択肢A", count: 3, percentage: 75 },
+            { label: "選択肢B", count: 1, percentage: 25 },
+          ],
+          total_votes: 4,
+          ends_at: "2026-07-26T03:42:53Z",
+          time_left_en: "Final results",
+        },
+      });
+      mockApi.getPostInformation.mockResolvedValue(createFxResponse(status));
+
+      const result = await adapter.fetchTweet("https://x.com/user/status/123");
+
+      expect(result?.poll).toEqual({
+        options: [
+          { label: "選択肢A", votes: 3, percentage: 75 },
+          { label: "選択肢B", votes: 1, percentage: 25 },
+        ],
+      });
+    });
+
+    it("投票情報がない場合 poll は undefined になる", async () => {
+      mockApi.getPostInformation.mockResolvedValue(createFxResponse(createFxStatus({ poll: undefined })));
+
+      const result = await adapter.fetchTweet("https://x.com/user/status/123");
+
+      expect(result?.poll).toBeUndefined();
+    });
+
+    it("選択肢が空の場合 poll は undefined になる", async () => {
+      const status = createFxStatus({
+        poll: {
+          choices: [],
+          total_votes: 0,
+          ends_at: "2026-07-26T03:42:53Z",
+          time_left_en: "Final results",
+        },
+      });
+      mockApi.getPostInformation.mockResolvedValue(createFxResponse(status));
+
+      const result = await adapter.fetchTweet("https://x.com/user/status/123");
+
+      expect(result?.poll).toBeUndefined();
+    });
+
     it("URL を fxtwitter 形式に変換してリクエストする", async () => {
       mockApi.getPostInformation.mockResolvedValue(
         createFxResponse(createFxStatus()),

--- a/tests/unit/adapters/twitter/VxTwitterAdapter.test.ts
+++ b/tests/unit/adapters/twitter/VxTwitterAdapter.test.ts
@@ -169,6 +169,48 @@ describe("VxTwitterAdapter", () => {
       expect(result?.metrics.retweets).toBe(50);
     });
 
+    it("投票情報を重複と順序を保持してTweetモデルへ変換できる", async () => {
+      const vxData = createVxTwitterData({
+        pollData: {
+          options: [
+            { name: "千冬ちゃん", votes: 2, percent: 50 },
+            { name: "千冬ちゃん", votes: 2, percent: 50 },
+          ],
+        },
+      });
+      mockApi.getPostInformation.mockResolvedValue(vxData);
+
+      const result = await adapter.fetchTweet("https://x.com/user/status/123");
+
+      expect(result?.poll).toEqual({
+        options: [
+          { label: "千冬ちゃん", votes: 2, percentage: 50 },
+          { label: "千冬ちゃん", votes: 2, percentage: 50 },
+        ],
+      });
+    });
+
+    it("投票情報がない場合 poll は undefined になる", async () => {
+      mockApi.getPostInformation.mockResolvedValue(createVxTwitterData({ pollData: null }));
+
+      const result = await adapter.fetchTweet("https://x.com/user/status/123");
+
+      expect(result?.poll).toBeUndefined();
+    });
+
+    it("有効な選択肢がない場合 poll は undefined になる", async () => {
+      const vxData = createVxTwitterData({
+        pollData: {
+          options: [{ name: "得票情報なし" }, { votes: 1, percent: 100 }],
+        },
+      });
+      mockApi.getPostInformation.mockResolvedValue(vxData);
+
+      const result = await adapter.fetchTweet("https://x.com/user/status/123");
+
+      expect(result?.poll).toBeUndefined();
+    });
+
     it("URL を vxtwitter 形式に変換してリクエストする", async () => {
       mockApi.getPostInformation.mockResolvedValue(createVxTwitterData());
 


### PR DESCRIPTION
## 概要

Twitter/Xの投票付きポストについて、選択肢・得票数・得票率をDiscord Embedへ表示できるようにします。

Closes #541

## 変更内容

- Coreの`Tweet`モデルへAPI非依存の投票モデルを追加
- VxTwitterの`pollData.options`を、順序と同名選択肢の重複を保持して変換
- FxTwitterの`poll.choices`をbest-effortで共通モデルへ変換
- Discord Embedへ番号付きpollフィールドを追加
- Discordのfield value上限である1,024文字に合わせて切り詰め
- AdapterとEmbedBuilderのunit test、および実装設計書を追加

## 背景・原因

両外部APIのレスポンス型には投票情報が存在していましたが、Coreの`Tweet`モデルへ正規化されておらず、Discord Embed生成でも参照されていませんでした。また、FxTwitterは同名選択肢を上流で重複排除するため、通常経路であるVxTwitterの配列順序と重複をそのまま保持します。

## ユーザーへの影響

投票付きポストを展開すると、各選択肢が番号、得票数、得票率とともに表示されます。投票のないポストの表示は変わりません。

## 検証

- `npx vitest run tests/unit`: 20 files / 258 tests passed
- `npm run lint`: passed
- `npm run compile:test`: passed
- `npm run build`: passed
- Issueの再現用ポストで、同名の2選択肢が別々の行に表示されることを確認
