### PR TITLE
fix(config): フォールバック既定を allow に統一しドキュメントと一致させる

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,12 +20,15 @@ HEALTH_PORT=9090
 
 # === Phase 2: Channel Config フォールバック設定 ===
 
-# Redis障害時のデフォルト動作
-# deny: 全チャンネル拒否（安全側、推奨）
-# allow: 全チャンネル許可（可用性優先）
-REDIS_DOWN_FALLBACK=deny
+# 既定はいずれも allow（可用性優先）。制限したい場合のみ deny を明示する。
+# 有効な設定は起動時に [ChannelConfig] Fallback policy: ... としてログ出力される。
 
-# 設定未作成時のデフォルト動作
-# deny: 全チャンネル拒否（新規ユーザー向け、推奨）
-# allow: 全チャンネル許可（既存ユーザー互換）
-CONFIG_NOT_FOUND_FALLBACK=deny
+# Redis障害時の動作（既定: allow）
+# allow: 全チャンネル許可（可用性優先）
+# deny : 全チャンネル拒否（障害中も whitelist を維持したい場合）
+REDIS_DOWN_FALLBACK=allow
+
+# 設定未作成時の動作（既定: allow）
+# allow: 全チャンネル許可（導入直後から使える）
+# deny : 全チャンネル拒否（Dashboard で設定するまで反応させない）
+CONFIG_NOT_FOUND_FALLBACK=allow

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ cp .env.example .env
 
 | 変数                        | 説明                                                 | デフォルト |
 | --------------------------- | ---------------------------------------------------- | ---------- |
-| `REDIS_DOWN_FALLBACK`       | Redis 障害時の挙動。`deny`: 全無視 / `allow`: 全許可 | `deny`     |
-| `CONFIG_NOT_FOUND_FALLBACK` | 設定未作成時の挙動                                   | `deny`     |
+| `REDIS_DOWN_FALLBACK`       | Redis 障害時の挙動。`allow`: 全許可 / `deny`: 全無視 | `allow`    |
+| `CONFIG_NOT_FOUND_FALLBACK` | 設定未作成時の挙動                                   | `allow`    |
 | `ENABLE_ORPHAN_CLEANUP`     | 起動時に孤立した設定キーを掃除                       | `false`    |
 
 ## 起動方法

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,8 +190,11 @@ Dashboard (Web UI)
 
 | 状態       | 環境変数                    | デフォルト | 挙動                       |
 | ---------- | --------------------------- | ---------- | -------------------------- |
-| Redis 障害 | `REDIS_DOWN_FALLBACK`       | `deny`     | 全チャンネル拒否（安全側） |
-| 設定未作成 | `CONFIG_NOT_FOUND_FALLBACK` | `deny`     | 全チャンネル拒否           |
+| Redis 障害 | `REDIS_DOWN_FALLBACK`       | `allow`    | 全チャンネル許可（可用性優先） |
+| 設定未作成 | `CONFIG_NOT_FOUND_FALLBACK` | `allow`    | 全チャンネル許可（導入直後から使える） |
+
+いずれも既定は `allow`。チャンネルを絞る運用者のみ `deny` を明示する。
+有効な設定は起動時に `[ChannelConfig] Fallback policy: ...` として INFO ログに出力される。
 
 ### 設定の三値型（ConfigResult）
 

--- a/docs/DASHBOARD_BOT_IMPLEMENTATION.md
+++ b/docs/DASHBOARD_BOT_IMPLEMENTATION.md
@@ -422,6 +422,7 @@ export class ChannelConfigService {
       
       case 'not_found': {
         // CONFIG_NOT_FOUND_FALLBACK に従う
+        // 注記(#549): 以下の既定値は設計当時のもの。現行の既定は両変数とも allow
         const fallback = process.env.CONFIG_NOT_FOUND_FALLBACK || 'deny';
         console.log(`[ChannelConfig] Config not found for ${guildId}, fallback: ${fallback}`);
         return fallback === 'allow';

--- a/docs/DASHBOARD_DEPLOYMENT.md
+++ b/docs/DASHBOARD_DEPLOYMENT.md
@@ -316,7 +316,8 @@ DATABASE_URL=file:/app/data/dashboard.db
 |--------|------|------|-----|
 | `DISCORD_BOT_TOKEN` | ✅ | Discord Bot トークン | `OTk...` |
 | `REDIS_URL` | ✅ | Redis 接続 URL | `redis://redis:6379` |
-| `REDIS_DOWN_FALLBACK` | - | Redis 障害時の挙動（`deny`/`allow`）デフォルト: `deny` | `deny` |
+| `REDIS_DOWN_FALLBACK` | - | Redis 障害時の挙動（`allow`/`deny`）デフォルト: `allow` | `allow` |
+| `CONFIG_NOT_FOUND_FALLBACK` | - | 設定未作成時の挙動（`allow`/`deny`）デフォルト: `allow` | `allow` |
 | `ENABLE_ORPHAN_CLEANUP` | - | 起動時の孤立キー掃除（デフォルト: `false`） | `false` |
 | `ENABLE_METRICS` | - | `/metrics` エンドポイント有効化（デフォルト: `false`） | `false` |
 
@@ -372,14 +373,25 @@ openssl rand -base64 32
 > 
 > **環境変数での切替**:
 > ```
-> REDIS_DOWN_FALLBACK=deny   # 全チャンネル拒否（★デフォルト、安全優先）
-> REDIS_DOWN_FALLBACK=allow  # 全チャンネル許可（可用性優先）
+> REDIS_DOWN_FALLBACK=allow  # 全チャンネル許可（★デフォルト、可用性優先）
+> REDIS_DOWN_FALLBACK=deny   # 全チャンネル拒否（障害中も whitelist を維持する）
 > ```
 > 
-> **デフォルトが `deny` である理由**:
-> - 配布版として、Redis 障害時に Bot が勝手にどこでも反応する状態は危険
-> - 荒らし耐性の観点からも、安全側に倒すべき
-> - 可用性を優先したい運用者は明示的に `allow` を選択できる
+> **デフォルトが `allow` である理由**:
+> - チャンネルを個別に絞る運用者はマイノリティであり、多数派は設定を触らない
+> - 既定を `deny` にすると、障害時に「Bot が壊れた」と見える形で多数派に影響が出る
+> - 制限したい運用者は `deny` を明示でき、その選択は起動時ログで確認できる
+> 
+> **受け入れているトレードオフ**:
+> - **Bot 再起動 × Redis 障害中**の交差では、インメモリキャッシュが空のまま `error` 経路に入るため、
+>   whitelist を設定済みのギルドでも一時的に全チャンネルで反応する
+> - ただし Redis エラー時にキャッシュは破棄されない（`not_found` のときのみ破棄）ため、
+>   障害中でもキャッシュに乗っているギルドは正常に動作し続ける。影響はキャッシュミス時に限定される
+> - この挙動を避けたい場合は `REDIS_DOWN_FALLBACK=deny` を明示する
+> 
+> **設定の確認方法**:
+> 起動時に `[ChannelConfig] Fallback policy: REDIS_DOWN=..., CONFIG_NOT_FOUND=...` が INFO ログに出力される。
+> 解釈できない値（`DENY` 以外の綴り違いなど）は WARN で警告され、既定の `allow` に倒れる。
 
 > **joined 復旧の運用考慮**:
 >
@@ -470,7 +482,7 @@ openssl rand -base64 32
 | **「セッションが切れました」が頻発** | Discord アクセストークンの期限切れ | 再ログインで復旧（仕様通りの動作） |
 | **チャンネル一覧が空のまま** | ① Bot がチャンネル情報を取得できていない ② Bot がオフライン | ① 「再取得ボタン」を押して 10分待つ ② Bot コンテナを確認 |
 | **設定変更が 409 Conflict になる** | 別のユーザー/タブが同時に設定を変更した | ページをリロードして最新の設定を取得し直す |
-| **Bot がどこでも反応しない** | ① Redis がダウン + `REDIS_DOWN_FALLBACK=deny` ② whitelist が空 | ① Redis コンテナを確認 ② Dashboard で whitelist を設定 |
+| **Bot がどこでも反応しない** | ① Redis がダウン + `REDIS_DOWN_FALLBACK=deny` を明示している ② `CONFIG_NOT_FOUND_FALLBACK=deny` を明示していて設定が未作成 ③ whitelist が空 | ① Redis コンテナを確認（既定の `allow` なら障害中も反応する） ② 起動時の `[ChannelConfig] Fallback policy` ログで有効値を確認 ③ Dashboard で whitelist を設定 |
 | **Dashboard が 503 を返す** | Redis への接続に失敗 | ① Redis コンテナを確認 ② `docker compose logs redis` でエラー確認 |
 
 ### ヘルスチェック手順

--- a/docs/DASHBOARD_SPEC.md
+++ b/docs/DASHBOARD_SPEC.md
@@ -225,8 +225,8 @@ Discord Bot「TwitterRX」において、特定のチャンネルでのみ応答
 │       │                         ✗                          │              │
 │       │                                            セッション失敗          │
 │       └── REDIS_DOWN_FALLBACK に従う                Dashboard ログイン不可  │
-│           deny（デフォルト）: 全メッセージ無視                               │
-│           allow: 全チャンネル許可（セキュリティリスク）                       │
+│           allow（デフォルト）: 全チャンネル許可                              │
+│           deny: 全メッセージ無視（whitelist を維持したい場合）                │
 │                                                                             │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                             │
@@ -250,18 +250,18 @@ Discord Bot「TwitterRX」において、特定のチャンネルでのみ応答
 >
 > | 状況 | Bot の挙動 | 説明 |
 > |------|------------|------|
-> | config キーが存在しない（not_found） | `CONFIG_NOT_FOUND_FALLBACK` に従う | デフォルト deny。allow にするには環境変数で明示 |
-> | Redis 自体に接続できない（error） | `REDIS_DOWN_FALLBACK` に従う | デフォルト deny。|
+> | config キーが存在しない（not_found） | `CONFIG_NOT_FOUND_FALLBACK` に従う | デフォルト allow。制限するには環境変数で `deny` を明示 |
+> | Redis 自体に接続できない（error） | `REDIS_DOWN_FALLBACK` に従う | デフォルト allow。|
 >
-> **これにより「設定未作成」と「Redis 障害」を明確に分離し、両方デフォルト deny で安全側に倒す。**
+> **これにより「設定未作成」と「Redis 障害」を明確に分離しつつ、両方デフォルト allow で可用性を優先する（#549）。**
 
 | 障害パターン | Bot の挙動 | Dashboard の挙動 | 復旧方法 |
 |-------------|-----------|-----------------|---------|
-| **Redis 死亡** | `REDIS_DOWN_FALLBACK` に従う（デフォルト: deny = 全無視） | ログイン不可、設定保存不可 | 自動復旧 |
+| **Redis 死亡** | `REDIS_DOWN_FALLBACK` に従う（デフォルト: allow = 全許可） | ログイン不可、設定保存不可 | 自動復旧 |
 | **pub/sub 切断** | 劣化モード（ギルド単位最小間隔で Redis GET） | 正常動作 | 自動再接続 |
 | **Bot 再起動** | 起動後に自動復旧 | 正常動作 | 自動復旧 |
 | **Dashboard 再起動** | 正常動作（Bot は影響なし） | 起動時に SQLite→Redis reseed | 自動復旧 |
-| **Redis キー消失** | `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: deny） | 起動時/10分ごとの reconcile で補完 | Dashboard 再起動で強制 reseed |
+| **Redis キー消失** | `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: allow） | 起動時/10分ごとの reconcile で補完 | Dashboard 再起動で強制 reseed |
 | **SQLite 破損** | Redis キャッシュが残っていれば継続動作 | DB エラー | バックアップから復元 |
 
 ---
@@ -319,6 +319,9 @@ interface ConfigAuditLog {
 ```
 
 ### 4.4 判定ロジック
+
+> **注記（#549 以降）**: 以下は設計当時の実装例であり、既定値は当時のもの。
+> 現行の既定は両変数とも `allow` で、実装は `src/core/services/ChannelConfigService.ts` の `parseFallback()` を参照。
 
 ```typescript
 function isChannelAllowed(guildId: string, channelId: string): boolean {
@@ -718,7 +721,7 @@ docker compose restart dashboard
 
 > **重要**: 
 > - Bot は SQLite を直接読み書きしない。Dashboard のみが SQLite を操作し、Redis を経由して Bot と同期する。
-> - **config の作成責任は Dashboard にある**。Bot は config がない場合 `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: deny）。
+> - **config の作成責任は Dashboard にある**。Bot は config がない場合 `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: allow）。
 > - Bot は `joined` フラグと `channels` キャッシュのみを管理する。
 
 > **★ P0対応: Redis消失時の復旧導線（SQLite→Redis再シード）**
@@ -1911,8 +1914,8 @@ export interface IChannelConfigRepository {
 
 - **isChannelAllowed**: ConfigResult.kind に応じて分岐
   - `found`: 設定に従う
-  - `not_found`: `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: deny）
-  - `error`: `REDIS_DOWN_FALLBACK` に従う（デフォルト: deny）
+  - `not_found`: `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: allow）
+  - `error`: `REDIS_DOWN_FALLBACK` に従う（デフォルト: allow）
 
 ### 9.2 MessageHandler への統合
 
@@ -3145,7 +3148,7 @@ dashboard/
 
 **フォールバック動作**:
 - 設定未作成（not_found）: `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルトは `ALLOW_ALL`）
-- Redis 障害（error）: `REDIS_DOWN_FALLBACK` に従う（デフォルトは `DENY_ALL`）
+- Redis 障害（error）: `REDIS_DOWN_FALLBACK` に従う（デフォルトは `ALLOW_ALL`）
 
 ### 9.3 ギルド参加/離脱イベント
 
@@ -3242,8 +3245,13 @@ async function checkHealthOnStartup(repository: RedisChannelConfigRepository): P
 
 > **★ P0対応: Redis 障害の可視化（MUST）**
 >
-> `REDIS_DOWN_FALLBACK=deny` はセキュリティ的に正しいが、Bot が黙って沈黙するだけだと
-> 運用者は「壊れた」と思い込んで問い合わせが殺到する。
+> **状況（#549 以降）**: 既定は `allow` になったため、Redis 障害で沈黙するのは
+> `REDIS_DOWN_FALLBACK=deny` を明示した運用者に限られる。
+> ただし「deny を明示したつもりが効いていない」ことにも気づけないため、
+> 起動時に `[ChannelConfig] Fallback policy: ...` を INFO 出力し、
+> 解釈できない値は WARN する実装を入れた（`parseFallback()`）。
+>
+> 以下は当時の提案内容。
 >
 > **MUST: Bot 側のログ出力**
 >
@@ -3325,6 +3333,7 @@ export class ChannelConfigService {
   }
 
   // ★ P0対応: ConfigResult（三値）を適切に処理
+  // 注記(#549): 以下の既定値は設計当時のもの。現行の既定は両変数とも allow
   async isChannelAllowed(guildId: string, channelId: string): Promise<boolean> {
     const result = await this.repository.getConfig(guildId);
     
@@ -3865,7 +3874,8 @@ DATABASE_URL=file:/app/data/dashboard.db
 |--------|------|------|-----|
 | `DISCORD_BOT_TOKEN` | ✅ | Discord Bot トークン | `OTk...` |
 | `REDIS_URL` | ✅ | Redis 接続 URL | `redis://redis:6379` |
-| `REDIS_DOWN_FALLBACK` | - | Redis 障害時の挙動（`deny`/`allow`）デフォルト: `deny` | `deny` |
+| `REDIS_DOWN_FALLBACK` | - | Redis 障害時の挙動（`allow`/`deny`）デフォルト: `allow` | `allow` |
+| `CONFIG_NOT_FOUND_FALLBACK` | - | 設定未作成時の挙動（`allow`/`deny`）デフォルト: `allow` | `allow` |
 | `ENABLE_ORPHAN_CLEANUP` | - | 起動時の孤立キー掃除（デフォルト: `false`） | `false` |
 | `ENABLE_METRICS` | - | `/metrics` エンドポイント有効化（デフォルト: `false`） | `false` |
 
@@ -4210,7 +4220,7 @@ if (ENABLE_METRICS) {
 | **503 時の UX 改善** | レスポンスに「保存完了の可能性」と現在 version を返す。UI は自動で GET し直して state を合わせる |
 | **BOT_NOT_JOINED_OR_OFFLINE** | joined 判定で Bot オフラインの可能性も示唆するエラーメッセージに改善 |
 | **getConfig() 三値化** | `ConfigResult` 型で `found`/`not_found`/`error` を明確に分離。Redis 障害と未設定を区別可能に |
-| **REDIS_DOWN_FALLBACK** | `error` 時に適用。`not_found`（未設定）は `CONFIG_NOT_FOUND_FALLBACK` に従う（両方デフォルト deny） |
+| **REDIS_DOWN_FALLBACK** | `error` 時に適用。`not_found`（未設定）は `CONFIG_NOT_FOUND_FALLBACK` に従う（両方デフォルト allow / #549 で deny から変更） |
 | **Nginx upstream 統一** | `/_astro/` も `twitterrx_dashboard_backend` に統一 |
 | **レート制限の原子化** | Lua スクリプトで ZREMRANGEBYSCORE → ZCARD → ZADD を原子的に実行 |
 | **ENCRYPTION_SALT 必須化** | デフォルト値を禁止、未設定時は起動失敗 |
@@ -4280,7 +4290,7 @@ if (ENABLE_METRICS) {
 
 - Bot は `joined` フラグと `channels` キャッシュのみ管理
 - Dashboard の `GET /api/guilds/{guildId}/config` で SQLite に行がなければデフォルト作成
-- Bot は config がない場合 `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: deny）
+- Bot は config がない場合 `CONFIG_NOT_FOUND_FALLBACK` に従う（デフォルト: allow）
 - 「設定は UI を開いた瞬間に整う」設計
 
 ### 14.6 guild.channels.cache の信頼性
@@ -4325,26 +4335,34 @@ if (ENABLE_METRICS) {
 > 
 > **環境変数での切替**:
 > ```
-> REDIS_DOWN_FALLBACK=deny   # 全チャンネル拒否（★デフォルト、安全優先）
-> REDIS_DOWN_FALLBACK=allow  # 全チャンネル許可（可用性優先）
+> REDIS_DOWN_FALLBACK=allow  # 全チャンネル許可（★デフォルト、可用性優先）
+> REDIS_DOWN_FALLBACK=deny   # 全チャンネル拒否（障害中も whitelist を維持する）
 > ```
 > 
-> **デフォルトが `deny` である理由**:
-> - 配布版として、Redis 障害時に Bot が勝手にどこでも反応する状態は危険
-> - 荒らし耐性の観点からも、安全側に倒すべき
-> - 可用性を優先したい運用者は明示的に `allow` を選択できる
+> **デフォルトが `allow` である理由**（#549 で deny から変更）:
+> - チャンネルを個別に絞る運用者はマイノリティであり、多数派は設定を触らない
+> - 既定を `deny` にすると、障害時に「Bot が壊れた」と見える形で多数派に影響が出る
+> - 制限したい運用者は `deny` を明示でき、その選択は起動時ログで確認できる
+> 
+> **受け入れているトレードオフ**:
+> - **Bot 再起動 × Redis 障害中**の交差では、インメモリキャッシュが空のまま `error` 経路に入るため、
+>   whitelist を設定済みのギルドでも一時的に全チャンネルで反応する
+> - ただし Redis エラー時にキャッシュは破棄されない（`not_found` のときのみ破棄）ため、
+>   障害中でもキャッシュに乗っているギルドは正常に動作し続ける。影響はキャッシュミス時に限定される
 > 
 > **★ P0対応: not_found も error も同じく環境変数で制御**
 > 
 > | 状況 | 適用する環境変数 | デフォルト |
 > |------|-------------------|------------|
-> | `not_found`（設定未作成） | `CONFIG_NOT_FOUND_FALLBACK` | `deny` |
-> | `error`（Redis障害） | `REDIS_DOWN_FALLBACK` | `deny` |
+> | `not_found`（設定未作成） | `CONFIG_NOT_FOUND_FALLBACK` | `allow` |
+> | `error`（Redis障害） | `REDIS_DOWN_FALLBACK` | `allow` |
 > 
-> **後方互換性が必要な場合（移行ガイド）**:
-> - 既存ユーザーは `CONFIG_NOT_FOUND_FALLBACK=allow` を設定することで従来動作を維持可能
-> - 新規ユーザーはデフォルト deny で安全に開始
-> - README に移行手順を必須記載（→ 移行ガイドセクション参照）
+> 値は `trim().toLowerCase()` で正規化される。解釈できない値は WARN を出して既定の `allow` に倒れる。
+> 有効な設定は起動時に `[ChannelConfig] Fallback policy: ...` として INFO ログに出力される。
+> 
+> **制限したい運用者向け**:
+> - `CONFIG_NOT_FOUND_FALLBACK=deny` … Dashboard で設定するまで反応させない
+> - `REDIS_DOWN_FALLBACK=deny` … 障害中も whitelist を維持する
 > 
 > **★ P0対応: 三値による明確な分離**
 > 
@@ -4480,7 +4498,7 @@ if (ENABLE_METRICS) {
 | **「セッションが切れました」が頻発** | Discord アクセストークンの期限切れ | 再ログインで復旧（仕様通りの動作） |
 | **チャンネル一覧が空のまま** | ① Bot がチャンネル情報を取得できていない ② Bot がオフライン | ① 「再取得ボタン」を押して 10分待つ ② Bot コンテナを確認 |
 | **設定変更が 409 Conflict になる** | 別のユーザー/タブが同時に設定を変更した | ページをリロードして最新の設定を取得し直す |
-| **Bot がどこでも反応しない** | ① Redis がダウン + `REDIS_DOWN_FALLBACK=deny` ② whitelist が空 | ① Redis コンテナを確認 ② Dashboard で whitelist を設定 |
+| **Bot がどこでも反応しない** | ① Redis がダウン + `REDIS_DOWN_FALLBACK=deny` を明示している ② `CONFIG_NOT_FOUND_FALLBACK=deny` を明示していて設定が未作成 ③ whitelist が空 | ① Redis コンテナを確認（既定の `allow` なら障害中も反応する） ② 起動時の `[ChannelConfig] Fallback policy` ログで有効値を確認 ③ Dashboard で whitelist を設定 |
 | **Dashboard が 503 を返す** | Redis への接続に失敗 | ① Redis コンテナを確認 ② `docker compose logs redis` でエラー確認 |
 
 ### ヘルスチェック手順

--- a/src/core/services/ChannelConfigService.ts
+++ b/src/core/services/ChannelConfigService.ts
@@ -6,11 +6,41 @@ import logger from "@/utils/logger";
 /** お知らせ配信先のデフォルト（未設定時はオーナーへの DM） */
 const DEFAULT_ANNOUNCE_TARGET: AnnounceTarget = { mode: "dm" };
 
+/** フォールバック方針。既定は allow（可用性優先）、制限したい運用者のみ deny を明示する */
+export type FallbackPolicy = "allow" | "deny";
+
+/**
+ * フォールバック設定の環境変数を解釈する
+ *
+ * 既定を allow に倒しているため、deny を明示した運用者が「設定が効いているか」を
+ * 確認できるよう、解釈できない値は警告する（起動時ログと合わせて誤設定を検知する）。
+ */
+const parseFallback = (raw: string | undefined, name: string): FallbackPolicy => {
+  const normalized = raw?.trim().toLowerCase();
+
+  if (!normalized) {
+    return "allow";
+  }
+
+  if (normalized === "allow" || normalized === "deny") {
+    return normalized;
+  }
+
+  logger.warn(`[ChannelConfig] Invalid ${name}="${raw}", falling back to "allow"`);
+  return "allow";
+};
+
 /**
  * P0対応: フォールバック設定
  */
-const REDIS_DOWN_FALLBACK = process.env.REDIS_DOWN_FALLBACK === "deny" ? "deny" : "allow";
-const CONFIG_NOT_FOUND_FALLBACK = process.env.CONFIG_NOT_FOUND_FALLBACK === "allow" ? "allow" : "deny";
+const REDIS_DOWN_FALLBACK = parseFallback(process.env.REDIS_DOWN_FALLBACK, "REDIS_DOWN_FALLBACK");
+const CONFIG_NOT_FOUND_FALLBACK = parseFallback(process.env.CONFIG_NOT_FOUND_FALLBACK, "CONFIG_NOT_FOUND_FALLBACK");
+
+/**
+ * 有効なフォールバック方針を取得する（起動時ログ用）
+ */
+export const getFallbackPolicy = () =>
+  ({ redisDown: REDIS_DOWN_FALLBACK, configNotFound: CONFIG_NOT_FOUND_FALLBACK }) as const;
 
 /**
  * チャンネル設定サービス

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import type { GuildDeliveryTarget } from "@/core/models/Announcement";
 import { AnnouncementService } from "@/core/services/AnnouncementService";
 import { ArticlePostService } from "@/core/services/ArticlePostService";
 import { BanService } from "@/core/services/BanService";
-import { ChannelConfigService } from "@/core/services/ChannelConfigService";
+import { ChannelConfigService, getFallbackPolicy } from "@/core/services/ChannelConfigService";
 import { MediaHandler } from "@/core/services/MediaHandler";
 import { TweetProcessor } from "@/core/services/TweetProcessor";
 import { RedisAnnouncementRepository } from "@/infrastructure/db/RedisAnnouncementRepository";
@@ -100,6 +100,12 @@ const articlePostRepository = new RedisArticlePostRepository();
 // P0: Channel Config Repository & Service
 const channelConfigRepository = new RedisChannelConfigRepository();
 const channelConfigService = new ChannelConfigService(channelConfigRepository);
+
+// 既定は allow のため、deny を明示した運用者が設定の反映を確認できるよう起動時に出力する
+const fallbackPolicy = getFallbackPolicy();
+logger.info(
+  `[ChannelConfig] Fallback policy: REDIS_DOWN=${fallbackPolicy.redisDown}, CONFIG_NOT_FOUND=${fallbackPolicy.configNotFound}`
+);
 
 // Core層
 const tweetProcessor = new TweetProcessor();

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -84,8 +84,8 @@ npm run test:e2e
 |--------|------|-----------|
 | `REDIS_URL` | Redis 接続 URL | `redis://localhost:6379` |
 | `DASHBOARD_URL` | Dashboard のベース URL | `http://localhost:4321` |
-| `CONFIG_NOT_FOUND_FALLBACK` | 設定未作成時の挙動 | `deny` |
-| `REDIS_DOWN_FALLBACK` | Redis 障害時の挙動 | `deny` |
+| `CONFIG_NOT_FOUND_FALLBACK` | 設定未作成時の挙動 | `allow` |
+| `REDIS_DOWN_FALLBACK` | Redis 障害時の挙動 | `allow` |
 
 ## 📝 テストの書き方
 

--- a/tests/unit/core/ChannelConfigService.test.ts
+++ b/tests/unit/core/ChannelConfigService.test.ts
@@ -32,24 +32,55 @@ const createGuildConfig = (
   ...overrides,
 });
 
+/**
+ * フォールバック設定はモジュールレベルで解決されるため、
+ * 環境変数を差し替えたうえで resetModules + 動的 import で読み直す。
+ * 併せて logger のモックも同じレジストリから取得し、警告出力を検証できるようにする。
+ */
+const loadService = async () => {
+  vi.resetModules();
+  // logger を先に読み込んでモジュールキャッシュに載せることで、
+  // サービス側が掴むモックと同一インスタンスを確実に参照する
+  const loggerModule = await import("@/utils/logger");
+  const service = await import("@/core/services/ChannelConfigService");
+
+  return {
+    ChannelConfigService: service.ChannelConfigService,
+    getFallbackPolicy: service.getFallbackPolicy,
+    warnMessages: vi
+      .mocked(loggerModule.default.warn)
+      .mock.calls.map((call) => String(call[0])),
+  };
+};
+
 // -------------------------
-// デフォルト環境（REDIS_DOWN_FALLBACK=allow / CONFIG_NOT_FOUND_FALLBACK=deny）
+// 既定環境（未設定 = REDIS_DOWN_FALLBACK:allow / CONFIG_NOT_FOUND_FALLBACK:allow）
 // -------------------------
-describe("ChannelConfigService (デフォルト環境)", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let ChannelConfigService: any;
+describe("ChannelConfigService (既定環境: 未設定)", () => {
+  let loaded: Awaited<ReturnType<typeof loadService>>;
   let mockRepo: IChannelConfigRepository;
 
   beforeAll(async () => {
     delete process.env.REDIS_DOWN_FALLBACK;
     delete process.env.CONFIG_NOT_FOUND_FALLBACK;
-    vi.resetModules();
-    ({ ChannelConfigService } =
-      await import("@/core/services/ChannelConfigService"));
+    loaded = await loadService();
   });
 
   beforeEach(() => {
     mockRepo = createMockRepo();
+  });
+
+  it("既定のフォールバック方針は両方とも allow", () => {
+    expect(loaded.getFallbackPolicy()).toEqual({
+      redisDown: "allow",
+      configNotFound: "allow",
+    });
+  });
+
+  it("未設定時に警告を出さない", () => {
+    expect(
+      loaded.warnMessages.filter((message) => message.includes("Invalid")),
+    ).toHaveLength(0);
   });
 
   describe("isChannelAllowed - kind: found", () => {
@@ -58,7 +89,7 @@ describe("ChannelConfigService (デフォルト環境)", () => {
         kind: "found",
         data: createGuildConfig({ allowAllChannels: true }),
       });
-      const service = new ChannelConfigService(mockRepo);
+      const service = new loaded.ChannelConfigService(mockRepo);
       expect(await service.isChannelAllowed("guild-1", "any-channel")).toBe(
         true,
       );
@@ -71,7 +102,7 @@ describe("ChannelConfigService (デフォルト環境)", () => {
           whitelistedChannelIds: ["channel-1", "channel-2"],
         }),
       });
-      const service = new ChannelConfigService(mockRepo);
+      const service = new loaded.ChannelConfigService(mockRepo);
       expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
     });
 
@@ -80,30 +111,28 @@ describe("ChannelConfigService (デフォルト環境)", () => {
         kind: "found",
         data: createGuildConfig({ whitelistedChannelIds: ["channel-1"] }),
       });
-      const service = new ChannelConfigService(mockRepo);
+      const service = new loaded.ChannelConfigService(mockRepo);
       expect(await service.isChannelAllowed("guild-1", "channel-999")).toBe(
         false,
       );
     });
   });
 
-  describe("isChannelAllowed - kind: not_found (デフォルト=deny)", () => {
-    it("設定が見つからない場合 false を返す", async () => {
+  describe("isChannelAllowed - kind: not_found (既定=allow)", () => {
+    it("設定が見つからない場合 true を返す", async () => {
       vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
-      const service = new ChannelConfigService(mockRepo);
-      expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(
-        false,
-      );
+      const service = new loaded.ChannelConfigService(mockRepo);
+      expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
     });
   });
 
-  describe("isChannelAllowed - kind: error (デフォルト REDIS_DOWN_FALLBACK=allow)", () => {
+  describe("isChannelAllowed - kind: error (既定=allow)", () => {
     it("Redis障害時 true を返す", async () => {
       vi.mocked(mockRepo.getConfig).mockResolvedValue({
         kind: "error",
         error: new Error("redis down"),
       });
-      const service = new ChannelConfigService(mockRepo);
+      const service = new loaded.ChannelConfigService(mockRepo);
       expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
     });
 
@@ -111,7 +140,7 @@ describe("ChannelConfigService (デフォルト環境)", () => {
       vi.mocked(mockRepo.getConfig).mockRejectedValue(
         new Error("unexpected failure"),
       );
-      const service = new ChannelConfigService(mockRepo);
+      const service = new loaded.ChannelConfigService(mockRepo);
       expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
     });
   });
@@ -122,7 +151,7 @@ describe("ChannelConfigService (デフォルト環境)", () => {
         ...createMockRepo(),
         performHealthCheck: vi.fn().mockResolvedValue(true),
       };
-      const service = new ChannelConfigService(mockRepoWithHealthCheck);
+      const service = new loaded.ChannelConfigService(mockRepoWithHealthCheck);
       expect(await service.performHealthCheck()).toBe(true);
     });
 
@@ -131,30 +160,27 @@ describe("ChannelConfigService (デフォルト環境)", () => {
         ...createMockRepo(),
         performHealthCheck: vi.fn().mockResolvedValue(false),
       };
-      const service = new ChannelConfigService(mockRepoWithHealthCheck);
+      const service = new loaded.ChannelConfigService(mockRepoWithHealthCheck);
       expect(await service.performHealthCheck()).toBe(false);
     });
 
     it("リポジトリが performHealthCheck をサポートしない場合 true を返す", async () => {
-      const service = new ChannelConfigService(mockRepo);
+      const service = new loaded.ChannelConfigService(mockRepo);
       expect(await service.performHealthCheck()).toBe(true);
     });
   });
 });
 
 // -------------------------
-// CONFIG_NOT_FOUND_FALLBACK=allow
+// CONFIG_NOT_FOUND_FALLBACK=deny（明示的に制限する運用）
 // -------------------------
-describe("ChannelConfigService (CONFIG_NOT_FOUND_FALLBACK=allow)", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let ChannelConfigService: any;
+describe("ChannelConfigService (CONFIG_NOT_FOUND_FALLBACK=deny)", () => {
+  let loaded: Awaited<ReturnType<typeof loadService>>;
   let mockRepo: IChannelConfigRepository;
 
   beforeAll(async () => {
-    vi.stubEnv("CONFIG_NOT_FOUND_FALLBACK", "allow");
-    vi.resetModules();
-    ({ ChannelConfigService } =
-      await import("@/core/services/ChannelConfigService"));
+    vi.stubEnv("CONFIG_NOT_FOUND_FALLBACK", "deny");
+    loaded = await loadService();
   });
 
   afterAll(() => {
@@ -165,26 +191,32 @@ describe("ChannelConfigService (CONFIG_NOT_FOUND_FALLBACK=allow)", () => {
     mockRepo = createMockRepo();
   });
 
-  it("設定が見つからない場合 true を返す", async () => {
+  it("設定が見つからない場合 false を返す", async () => {
     vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
-    const service = new ChannelConfigService(mockRepo);
+    const service = new loaded.ChannelConfigService(mockRepo);
+    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
+  });
+
+  it("Redis障害時は影響を受けず true を返す", async () => {
+    vi.mocked(mockRepo.getConfig).mockResolvedValue({
+      kind: "error",
+      error: new Error("redis down"),
+    });
+    const service = new loaded.ChannelConfigService(mockRepo);
     expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
   });
 });
 
 // -------------------------
-// REDIS_DOWN_FALLBACK=deny
+// REDIS_DOWN_FALLBACK=deny（障害中も whitelist を維持する運用）
 // -------------------------
 describe("ChannelConfigService (REDIS_DOWN_FALLBACK=deny)", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let ChannelConfigService: any;
+  let loaded: Awaited<ReturnType<typeof loadService>>;
   let mockRepo: IChannelConfigRepository;
 
   beforeAll(async () => {
     vi.stubEnv("REDIS_DOWN_FALLBACK", "deny");
-    vi.resetModules();
-    ({ ChannelConfigService } =
-      await import("@/core/services/ChannelConfigService"));
+    loaded = await loadService();
   });
 
   afterAll(() => {
@@ -200,7 +232,7 @@ describe("ChannelConfigService (REDIS_DOWN_FALLBACK=deny)", () => {
       kind: "error",
       error: new Error("redis down"),
     });
-    const service = new ChannelConfigService(mockRepo);
+    const service = new loaded.ChannelConfigService(mockRepo);
     expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
   });
 
@@ -208,7 +240,88 @@ describe("ChannelConfigService (REDIS_DOWN_FALLBACK=deny)", () => {
     vi.mocked(mockRepo.getConfig).mockRejectedValue(
       new Error("unexpected failure"),
     );
-    const service = new ChannelConfigService(mockRepo);
+    const service = new loaded.ChannelConfigService(mockRepo);
     expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
+  });
+
+  it("設定未作成時は影響を受けず true を返す", async () => {
+    vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
+    const service = new loaded.ChannelConfigService(mockRepo);
+    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
+  });
+});
+
+// -------------------------
+// 値の正規化（大文字・前後空白を許容する）
+// -------------------------
+describe("ChannelConfigService (値の正規化)", () => {
+  let loaded: Awaited<ReturnType<typeof loadService>>;
+
+  beforeAll(async () => {
+    vi.stubEnv("REDIS_DOWN_FALLBACK", " DENY ");
+    vi.stubEnv("CONFIG_NOT_FOUND_FALLBACK", "Deny");
+    loaded = await loadService();
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("大文字・前後空白を含む値も deny として解釈する", () => {
+    expect(loaded.getFallbackPolicy()).toEqual({
+      redisDown: "deny",
+      configNotFound: "deny",
+    });
+  });
+
+  it("正規化できた値に対しては警告を出さない", () => {
+    expect(
+      loaded.warnMessages.filter((message) => message.includes("Invalid")),
+    ).toHaveLength(0);
+  });
+});
+
+// -------------------------
+// 不正値（既定へ倒しつつ警告する）
+// -------------------------
+describe("ChannelConfigService (不正値)", () => {
+  let loaded: Awaited<ReturnType<typeof loadService>>;
+  let mockRepo: IChannelConfigRepository;
+
+  beforeAll(async () => {
+    vi.stubEnv("REDIS_DOWN_FALLBACK", "maybe");
+    loaded = await loadService();
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  beforeEach(() => {
+    mockRepo = createMockRepo();
+  });
+
+  it("解釈できない値は既定の allow に倒す", () => {
+    expect(loaded.getFallbackPolicy().redisDown).toBe("allow");
+  });
+
+  it("解釈できない値を警告する", () => {
+    expect(
+      loaded.warnMessages.some(
+        (message) =>
+          message.includes("Invalid") &&
+          message.includes("REDIS_DOWN_FALLBACK") &&
+          message.includes("maybe"),
+      ),
+    ).toBe(true);
+  });
+
+  it("Redis障害時は既定どおり true を返す", async () => {
+    vi.mocked(mockRepo.getConfig).mockResolvedValue({
+      kind: "error",
+      error: new Error("redis down"),
+    });
+    const service = new loaded.ChannelConfigService(mockRepo);
+    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
   });
 });


### PR DESCRIPTION
## 概要

`REDIS_DOWN_FALLBACK` と `CONFIG_NOT_FOUND_FALLBACK` で既定値の向きが逆になっており、かつ両方ともドキュメント記載と一致していなかった問題を解消する。

**既定を `allow` に統一し、制限したい運用者のみ `deny` を明示する**規則に揃えた。

Closes #549

## 方針転換について

Issue では当初「コード既定を `deny` に寄せる（fail-closed）」と決定していたが、以下の確認を経て**方針を反転**している。詳細な議論は [#549 のコメント](https://github.com/rx-twitter/rx-twitter/issues/549#issuecomment-5132812736) を参照。

1. **本番 `.env` は両変数とも `allow` を明示済み**。コード既定を何に変えても稼働中の Bot の挙動は変わらず、当初「セキュリティ改善」としていた変更は実際には稼働環境の姿勢を一切改善しないものだった。
2. **Dashboard は本件に無関係**。`rx-twitter/rx-twitter-dashboard` を code search した結果、両変数の参照は **0 件**（同リポジトリが検索対象に含まれることは `REDIS_URL` のヒットで確認）。チャンネル許可判定を持つのは Bot 側の `ChannelConfigService` のみ。
3. **運用実態**: チャンネルを個別に絞る運用者はマイノリティ。既定を `deny` にすると「導入したのに反応しない」を生む。実際、未設定の環境では `CONFIG_NOT_FOUND_FALLBACK=deny` 既定により**新規ギルドで Bot が沈黙していた**。

### 変更前後

| 変数 | コード既定(変更前) | `.env.example`(変更前) | 本番 | 変更後 |
|---|---|---|---|---|
| `REDIS_DOWN_FALLBACK` | allow | deny | allow | **allow**（コード維持・doc 修正） |
| `CONFIG_NOT_FOUND_FALLBACK` | deny | deny | allow | **allow**（コード修正・doc 修正） |

変更後は **コード既定 == `.env.example` == 本番** が一致し、「既定は allow。絞りたい人だけ deny を明示」の一文で説明が完結する。

## 変更内容

### コード

- `src/core/services/ChannelConfigService.ts`
  - 2 つの三項演算子を共通パーサ `parseFallback()` に統一（既定 `allow`）
  - 解釈できない値は WARN を出して既定へ倒す
  - 値を `trim().toLowerCase()` で正規化（`src/config/config.ts` の `LOG_LEVEL` に倣う）
  - `getFallbackPolicy()` を export
- `src/index.ts`: DI 配線直後に有効な方針を INFO ログ出力

既定が `allow` だと、`deny` を明示した運用者は「設定が効いているか」を確認できない。**起動時ログ + 誤設定警告の二段構え**でこれを補う（`docs/DASHBOARD_SPEC.md` で提案され未実装だったもの）。

### テスト

`tests/unit/core/ChannelConfigService.test.ts` を再構成（t-wada スタイルで red → green を確認）。

| ブロック | 内容 |
|---|---|
| 既定（未設定） | `not_found` / `error` / 例外 → すべて `true` |
| `CONFIG_NOT_FOUND_FALLBACK=deny` | `not_found` → `false`、`error` は影響を受けない |
| `REDIS_DOWN_FALLBACK=deny` | `error` / 例外 → `false`、`not_found` は影響を受けない |
| 値の正規化 | `" DENY "` / `"Deny"` → `deny`、警告なし |
| 不正値 | `"maybe"` → `allow` + WARN |

### ドキュメント

規範的な記述の既定を `allow` に更新（`README.md` / `docs/ARCHITECTURE.md` / `docs/DASHBOARD_DEPLOYMENT.md` / `docs/DASHBOARD_SPEC.md` / `tests/e2e/README.md` / `.env.example`）。

- 「デフォルトが `deny` である理由」ブロックは**理由ごと差し替え**、受け入れたトレードオフを明記
- `.env.example` は「推奨」表記をやめ、既定と選択肢として記述
- **過去の不具合記録・設計当時の実装例は履歴として保存**し、注記のみ追加（`DASHBOARD_SPEC.md` 3 箇所、`DASHBOARD_BOT_IMPLEMENTATION.md` 1 箇所）

## 受け入れているトレードオフ

**Bot 再起動 × Redis 障害中**の交差では、インメモリキャッシュが空のまま `error` 経路に入るため、whitelist を設定済みのギルドでも一時的に全チャンネルで反応する。

ただし `RedisChannelConfigRepository` は Redis エラー時にキャッシュを破棄しない（`not_found` のときのみ破棄）ため、**障害中でもキャッシュに乗っているギルドは正常に動作し続ける**。影響はキャッシュミス時に限定される。

これを避けたい運用者は `REDIS_DOWN_FALLBACK=deny` を明示できる。ドキュメントにも明記した。

## リリース影響

- **稼働中の本番: 挙動不変**（両変数 `allow` を明示済み）
- 自前ホストで未設定の環境: 新規ギルドで沈黙 → 反応する、に変化（onboarding の改善）
- `fix:` で patch リリース。`BREAKING CHANGE` は付けない

## 検証

品質ゲート（AGENTS.md）:

- `npm run lint` — 警告/エラー ゼロ
- `npm run compile:test` — 型エラー ゼロ
- `npm run build` — 正常完了
- `npm run test:unit` — **28 files / 350 tests passed**

ビルド済み `dist/` を実際に実行して確認:

| 環境変数 | 結果 |
|---|---|
| 未設定 | `{redisDown:"allow", configNotFound:"allow"}` |
| `deny` 明示 | `{redisDown:"deny", configNotFound:"deny"}` |
| `" DENY "` | `{redisDown:"deny"}` — 正規化が機能 |
| `maybe` | WARN 出力 → `allow` に着地 |

**未確認**: `src/index.ts` の起動時 INFO ログは Bot 本体の起動（Discord トークン + Redis 接続）が必要なため、実際の出力は未確認。コンパイルと配置のみ確認済み。

```bash
docker compose up -d && docker compose logs twitter-rx | grep "Fallback policy"
```

## スコープ外（別 Issue 候補）

1. `RedisChannelConfigRepository.isChannelAllowed()` が env を参照せず `not_found` / `error` を無条件 `return true`。allow 統一で既定の結果は一致するが、**明示された `deny` は依然無視される**二重実装。
2. Core からの `process.env` 追い出し（`FallbackPolicy` を `src/index.ts` で注入）。AGENTS.md「Core は外部依存ゼロ」との整合。
3. `.env.example` に未記載の `ENABLE_ORPHAN_CLEANUP` / `ENABLE_METRICS` の追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
