### PR TITLE
refactor(core): フォールバック方針の解決を Core から追い出し DI に置き換える

### DIFF
--- a/src/config/fallbackPolicy.ts
+++ b/src/config/fallbackPolicy.ts
@@ -1,0 +1,35 @@
+import type { FallbackPolicies, FallbackPolicy } from "@/core/services/ChannelConfigService";
+import logger from "@/utils/logger";
+
+/**
+ * フォールバック設定の環境変数を解釈する
+ *
+ * 既定は allow（可用性優先）。制限したい運用者のみ deny を明示する。
+ * 既定を allow に倒しているため、deny を明示した運用者が「設定が効いているか」を
+ * 確認できるよう、解釈できない値は警告する（起動時ログと合わせて誤設定を検知する）。
+ */
+const parseFallback = (raw: string | undefined, name: string): FallbackPolicy => {
+  const normalized = raw?.trim().toLowerCase();
+
+  if (!normalized) {
+    return "allow";
+  }
+
+  if (normalized === "allow" || normalized === "deny") {
+    return normalized;
+  }
+
+  logger.warn(`[ChannelConfig] Invalid ${name}="${raw}", falling back to "allow"`);
+  return "allow";
+};
+
+/**
+ * 環境変数からフォールバック方針を解決する
+ *
+ * 環境を引数で受け取るため、テストからは任意の環境を直接渡せる。
+ * @param env 解釈対象の環境変数（既定は process.env）
+ */
+export const resolveFallbackPolicies = (env: NodeJS.ProcessEnv = process.env): FallbackPolicies => ({
+  redisDown: parseFallback(env.REDIS_DOWN_FALLBACK, "REDIS_DOWN_FALLBACK"),
+  configNotFound: parseFallback(env.CONFIG_NOT_FOUND_FALLBACK, "CONFIG_NOT_FOUND_FALLBACK"),
+});

--- a/src/core/services/ChannelConfigService.ts
+++ b/src/core/services/ChannelConfigService.ts
@@ -10,44 +10,27 @@ const DEFAULT_ANNOUNCE_TARGET: AnnounceTarget = { mode: "dm" };
 export type FallbackPolicy = "allow" | "deny";
 
 /**
- * フォールバック設定の環境変数を解釈する
+ * 判定不能時に適用する方針
  *
- * 既定を allow に倒しているため、deny を明示した運用者が「設定が効いているか」を
- * 確認できるよう、解釈できない値は警告する（起動時ログと合わせて誤設定を検知する）。
+ * 環境変数の解釈は Core の責務ではないため、src/config/fallbackPolicy.ts で
+ * 解決したものを src/index.ts から注入する。
  */
-const parseFallback = (raw: string | undefined, name: string): FallbackPolicy => {
-  const normalized = raw?.trim().toLowerCase();
-
-  if (!normalized) {
-    return "allow";
-  }
-
-  if (normalized === "allow" || normalized === "deny") {
-    return normalized;
-  }
-
-  logger.warn(`[ChannelConfig] Invalid ${name}="${raw}", falling back to "allow"`);
-  return "allow";
-};
-
-/**
- * P0対応: フォールバック設定
- */
-const REDIS_DOWN_FALLBACK = parseFallback(process.env.REDIS_DOWN_FALLBACK, "REDIS_DOWN_FALLBACK");
-const CONFIG_NOT_FOUND_FALLBACK = parseFallback(process.env.CONFIG_NOT_FOUND_FALLBACK, "CONFIG_NOT_FOUND_FALLBACK");
-
-/**
- * 有効なフォールバック方針を取得する（起動時ログ用）
- */
-export const getFallbackPolicy = () =>
-  ({ redisDown: REDIS_DOWN_FALLBACK, configNotFound: CONFIG_NOT_FOUND_FALLBACK }) as const;
+export interface FallbackPolicies {
+  /** Redis 障害時（ConfigResult.kind === "error"） */
+  redisDown: FallbackPolicy;
+  /** 設定未作成時（ConfigResult.kind === "not_found"） */
+  configNotFound: FallbackPolicy;
+}
 
 /**
  * チャンネル設定サービス
  * Bot側でチャンネル許可判定を行う
  */
 export class ChannelConfigService {
-  constructor(private readonly repository: IChannelConfigRepository) {}
+  constructor(
+    private readonly repository: IChannelConfigRepository,
+    private readonly policies: FallbackPolicies
+  ) {}
 
   /**
    * P0: isChannelAllowed で ConfigResult.kind に応じた分岐
@@ -71,16 +54,16 @@ export class ChannelConfigService {
         case "not_found":
           // P0: 設定が見つからない場合は CONFIG_NOT_FOUND_FALLBACK を適用
           logger.warn(
-            `[ChannelConfig] Config not found for guild ${guildId}, applying CONFIG_NOT_FOUND_FALLBACK: ${CONFIG_NOT_FOUND_FALLBACK}`
+            `[ChannelConfig] Config not found for guild ${guildId}, applying CONFIG_NOT_FOUND_FALLBACK: ${this.policies.configNotFound}`
           );
-          return CONFIG_NOT_FOUND_FALLBACK === "allow";
+          return this.policies.configNotFound === "allow";
 
         case "error":
           // P0: Redis障害時はフォールバック設定を適用
           logger.error(`[ChannelConfig] Error fetching config for guild ${guildId}: ${result.error.message}`);
-          logger.warn(`[ChannelConfig] Applying REDIS_DOWN_FALLBACK: ${REDIS_DOWN_FALLBACK}`);
+          logger.warn(`[ChannelConfig] Applying REDIS_DOWN_FALLBACK: ${this.policies.redisDown}`);
 
-          if (REDIS_DOWN_FALLBACK === "deny") {
+          if (this.policies.redisDown === "deny") {
             return false;
           } else {
             return true;
@@ -90,7 +73,7 @@ export class ChannelConfigService {
           // TypeScript exhaustiveness check
           const _exhaustive: never = result;
           logger.error(`[ChannelConfig] Unexpected ConfigResult kind: ${JSON.stringify(_exhaustive)}`);
-          return REDIS_DOWN_FALLBACK === "allow";
+          return this.policies.redisDown === "allow";
         }
       }
     } catch (err) {
@@ -98,7 +81,7 @@ export class ChannelConfigService {
       logger.error(`[ChannelConfig] Unexpected error in isChannelAllowed:`, err);
 
       // フォールバック設定を適用
-      return REDIS_DOWN_FALLBACK === "allow";
+      return this.policies.redisDown === "allow";
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import type { GuildDeliveryTarget } from "@/core/models/Announcement";
 import { AnnouncementService } from "@/core/services/AnnouncementService";
 import { ArticlePostService } from "@/core/services/ArticlePostService";
 import { BanService } from "@/core/services/BanService";
-import { ChannelConfigService, getFallbackPolicy } from "@/core/services/ChannelConfigService";
+import { ChannelConfigService } from "@/core/services/ChannelConfigService";
 import { MediaHandler } from "@/core/services/MediaHandler";
 import { TweetProcessor } from "@/core/services/TweetProcessor";
 import { RedisAnnouncementRepository } from "@/infrastructure/db/RedisAnnouncementRepository";
@@ -32,6 +32,7 @@ import { cleanupOrphanedConfigs } from "@/utils/cleanupOrphanedConfigs";
 import logger from "@/utils/logger";
 
 import config, { ROOT_DIR } from "./config/config";
+import { resolveFallbackPolicies } from "./config/fallbackPolicy";
 import { connectRedis } from "./db/connect";
 import { redis } from "./db/init";
 import { deleteReply, popReply } from "./db/replyLogger";
@@ -98,13 +99,13 @@ const replyLogger = new RedisReplyLogger();
 const articlePostRepository = new RedisArticlePostRepository();
 
 // P0: Channel Config Repository & Service
+const fallbackPolicies = resolveFallbackPolicies();
 const channelConfigRepository = new RedisChannelConfigRepository();
-const channelConfigService = new ChannelConfigService(channelConfigRepository);
+const channelConfigService = new ChannelConfigService(channelConfigRepository, fallbackPolicies);
 
 // 既定は allow のため、deny を明示した運用者が設定の反映を確認できるよう起動時に出力する
-const fallbackPolicy = getFallbackPolicy();
 logger.info(
-  `[ChannelConfig] Fallback policy: REDIS_DOWN=${fallbackPolicy.redisDown}, CONFIG_NOT_FOUND=${fallbackPolicy.configNotFound}`
+  `[ChannelConfig] Fallback policy: REDIS_DOWN=${fallbackPolicies.redisDown}, CONFIG_NOT_FOUND=${fallbackPolicies.configNotFound}`
 );
 
 // Core層

--- a/tests/e2e/channel-config.test.ts
+++ b/tests/e2e/channel-config.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { getTestRedis, closeTestRedis, cleanupTestData, setupTestGuildConfig, generateTestGuildId } from "./helpers";
+import { resolveFallbackPolicies } from "../../src/config/fallbackPolicy";
 import { ChannelConfigService } from "../../src/core/services/ChannelConfigService";
 import { RedisChannelConfigRepository } from "../../src/infrastructure/db/RedisChannelConfigRepository";
 
@@ -24,7 +25,7 @@ describe("E2E: チャンネル設定機能", () => {
 
       // Repository と Service を初期化
       configRepository = new RedisChannelConfigRepository();
-      configService = new ChannelConfigService(configRepository);
+      configService = new ChannelConfigService(configRepository, resolveFallbackPolicies());
     } catch {
       console.warn("[E2E] Skipping tests: Redis is not available");
       redisAvailable = false;

--- a/tests/unit/config/fallbackPolicy.test.ts
+++ b/tests/unit/config/fallbackPolicy.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { resolveFallbackPolicies } from "@/config/fallbackPolicy";
+import logger from "@/utils/logger";
+
+describe("resolveFallbackPolicies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("未設定なら両方とも allow", () => {
+    expect(resolveFallbackPolicies({})).toEqual({
+      redisDown: "allow",
+      configNotFound: "allow",
+    });
+  });
+
+  it("空文字は未設定として扱う", () => {
+    expect(resolveFallbackPolicies({ REDIS_DOWN_FALLBACK: "" })).toEqual({
+      redisDown: "allow",
+      configNotFound: "allow",
+    });
+  });
+
+  it("deny を明示した場合のみ deny になる", () => {
+    expect(
+      resolveFallbackPolicies({
+        REDIS_DOWN_FALLBACK: "deny",
+        CONFIG_NOT_FOUND_FALLBACK: "deny",
+      }),
+    ).toEqual({ redisDown: "deny", configNotFound: "deny" });
+  });
+
+  it("2つの変数は独立して解釈される", () => {
+    expect(
+      resolveFallbackPolicies({ CONFIG_NOT_FOUND_FALLBACK: "deny" }),
+    ).toEqual({ redisDown: "allow", configNotFound: "deny" });
+  });
+
+  it("大文字・前後空白を正規化する", () => {
+    expect(
+      resolveFallbackPolicies({
+        REDIS_DOWN_FALLBACK: " DENY ",
+        CONFIG_NOT_FOUND_FALLBACK: "Allow",
+      }),
+    ).toEqual({ redisDown: "deny", configNotFound: "allow" });
+  });
+
+  it("正規化できた値では警告を出さない", () => {
+    resolveFallbackPolicies({ REDIS_DOWN_FALLBACK: " DENY " });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("解釈できない値は既定の allow に倒す", () => {
+    expect(resolveFallbackPolicies({ REDIS_DOWN_FALLBACK: "maybe" })).toEqual({
+      redisDown: "allow",
+      configNotFound: "allow",
+    });
+  });
+
+  it("解釈できない値を変数名と実際の値つきで警告する", () => {
+    resolveFallbackPolicies({ REDIS_DOWN_FALLBACK: "maybe" });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [message] = vi.mocked(logger.warn).mock.calls[0] as unknown as [string];
+    expect(message).toContain("REDIS_DOWN_FALLBACK");
+    expect(message).toContain("maybe");
+  });
+
+  it("引数を省略した場合は process.env を読む", () => {
+    vi.stubEnv("REDIS_DOWN_FALLBACK", "deny");
+
+    expect(resolveFallbackPolicies().redisDown).toBe("deny");
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/tests/unit/core/ChannelConfigService.test.ts
+++ b/tests/unit/core/ChannelConfigService.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IChannelConfigRepository, GuildConfig } from "@rx-twitter/shared";
 
@@ -14,15 +6,16 @@ vi.mock("@/utils/logger", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+import type { FallbackPolicies } from "@/core/services/ChannelConfigService";
+import { ChannelConfigService } from "@/core/services/ChannelConfigService";
+
 const createMockRepo = (): IChannelConfigRepository => ({
   getConfig: vi.fn(),
   saveConfig: vi.fn(),
   notifyUpdate: vi.fn(),
 });
 
-const createGuildConfig = (
-  overrides: Partial<GuildConfig> = {},
-): GuildConfig => ({
+const createGuildConfig = (overrides: Partial<GuildConfig> = {}): GuildConfig => ({
   guildId: "guild-1",
   allowAllChannels: false,
   whitelistedChannelIds: [],
@@ -31,55 +24,15 @@ const createGuildConfig = (
   ...overrides,
 });
 
-/**
- * フォールバック設定はモジュールレベルで解決されるため、
- * 環境変数を差し替えたうえで resetModules + 動的 import で読み直す。
- * 併せて logger のモックも同じレジストリから取得し、警告出力を検証できるようにする。
- */
-const loadService = async () => {
-  vi.resetModules();
-  // logger を先に読み込んでモジュールキャッシュに載せることで、
-  // サービス側が掴むモックと同一インスタンスを確実に参照する
-  const loggerModule = await import("@/utils/logger");
-  const service = await import("@/core/services/ChannelConfigService");
+/** 既定（両方 allow）の方針。制限する運用は個別に上書きする */
+const ALLOW_ALL: FallbackPolicies = { redisDown: "allow", configNotFound: "allow" };
 
-  return {
-    ChannelConfigService: service.ChannelConfigService,
-    getFallbackPolicy: service.getFallbackPolicy,
-    warnMessages: vi
-      .mocked(loggerModule.default.warn)
-      .mock.calls.map((call) => String(call[0])),
-  };
-};
-
-// -------------------------
-// 既定環境（未設定 = REDIS_DOWN_FALLBACK:allow / CONFIG_NOT_FOUND_FALLBACK:allow）
-// -------------------------
-describe("ChannelConfigService (既定環境: 未設定)", () => {
-  let loaded: Awaited<ReturnType<typeof loadService>>;
+describe("ChannelConfigService", () => {
   let mockRepo: IChannelConfigRepository;
-
-  beforeAll(async () => {
-    delete process.env.REDIS_DOWN_FALLBACK;
-    delete process.env.CONFIG_NOT_FOUND_FALLBACK;
-    loaded = await loadService();
-  });
 
   beforeEach(() => {
     mockRepo = createMockRepo();
-  });
-
-  it("既定のフォールバック方針は両方とも allow", () => {
-    expect(loaded.getFallbackPolicy()).toEqual({
-      redisDown: "allow",
-      configNotFound: "allow",
-    });
-  });
-
-  it("未設定時に警告を出さない", () => {
-    expect(
-      loaded.warnMessages.filter((message) => message.includes("Invalid")),
-    ).toHaveLength(0);
+    vi.clearAllMocks();
   });
 
   describe("isChannelAllowed - kind: found", () => {
@@ -88,20 +41,18 @@ describe("ChannelConfigService (既定環境: 未設定)", () => {
         kind: "found",
         data: createGuildConfig({ allowAllChannels: true }),
       });
-      const service = new loaded.ChannelConfigService(mockRepo);
-      expect(await service.isChannelAllowed("guild-1", "any-channel")).toBe(
-        true,
-      );
+      const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
+
+      expect(await service.isChannelAllowed("guild-1", "any-channel")).toBe(true);
     });
 
     it("ホワイトリストにチャンネルが含まれる場合 true を返す", async () => {
       vi.mocked(mockRepo.getConfig).mockResolvedValue({
         kind: "found",
-        data: createGuildConfig({
-          whitelistedChannelIds: ["channel-1", "channel-2"],
-        }),
+        data: createGuildConfig({ whitelistedChannelIds: ["channel-1", "channel-2"] }),
       });
-      const service = new loaded.ChannelConfigService(mockRepo);
+      const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
+
       expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
     });
 
@@ -110,217 +61,128 @@ describe("ChannelConfigService (既定環境: 未設定)", () => {
         kind: "found",
         data: createGuildConfig({ whitelistedChannelIds: ["channel-1"] }),
       });
-      const service = new loaded.ChannelConfigService(mockRepo);
-      expect(await service.isChannelAllowed("guild-1", "channel-999")).toBe(
-        false,
-      );
+      const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
+
+      expect(await service.isChannelAllowed("guild-1", "channel-999")).toBe(false);
+    });
+
+    it("フォールバック方針に関わらず設定内容が優先される", async () => {
+      vi.mocked(mockRepo.getConfig).mockResolvedValue({
+        kind: "found",
+        data: createGuildConfig({ allowAllChannels: true }),
+      });
+      const service = new ChannelConfigService(mockRepo, {
+        redisDown: "deny",
+        configNotFound: "deny",
+      });
+
+      expect(await service.isChannelAllowed("guild-1", "any-channel")).toBe(true);
     });
   });
 
-  describe("isChannelAllowed - kind: not_found (既定=allow)", () => {
-    it("設定が見つからない場合 true を返す", async () => {
+  describe("isChannelAllowed - kind: not_found", () => {
+    beforeEach(() => {
       vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
-      const service = new loaded.ChannelConfigService(mockRepo);
+    });
+
+    it("configNotFound=allow なら true を返す", async () => {
+      const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
+
+      expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
+    });
+
+    it("configNotFound=deny なら false を返す", async () => {
+      const service = new ChannelConfigService(mockRepo, {
+        ...ALLOW_ALL,
+        configNotFound: "deny",
+      });
+
+      expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
+    });
+
+    it("redisDown の方針には影響されない", async () => {
+      const service = new ChannelConfigService(mockRepo, {
+        redisDown: "deny",
+        configNotFound: "allow",
+      });
+
       expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
     });
   });
 
-  describe("isChannelAllowed - kind: error (既定=allow)", () => {
-    it("Redis障害時 true を返す", async () => {
+  describe("isChannelAllowed - kind: error", () => {
+    beforeEach(() => {
       vi.mocked(mockRepo.getConfig).mockResolvedValue({
         kind: "error",
         error: new Error("redis down"),
       });
-      const service = new loaded.ChannelConfigService(mockRepo);
+    });
+
+    it("redisDown=allow なら true を返す", async () => {
+      const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
+
       expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
     });
 
-    it("getConfig が例外を投げた場合 true を返す", async () => {
-      vi.mocked(mockRepo.getConfig).mockRejectedValue(
-        new Error("unexpected failure"),
-      );
-      const service = new loaded.ChannelConfigService(mockRepo);
+    it("redisDown=deny なら false を返す", async () => {
+      const service = new ChannelConfigService(mockRepo, {
+        ...ALLOW_ALL,
+        redisDown: "deny",
+      });
+
+      expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
+    });
+
+    it("configNotFound の方針には影響されない", async () => {
+      const service = new ChannelConfigService(mockRepo, {
+        redisDown: "allow",
+        configNotFound: "deny",
+      });
+
       expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
+    });
+  });
+
+  describe("isChannelAllowed - 予期しない例外", () => {
+    beforeEach(() => {
+      vi.mocked(mockRepo.getConfig).mockRejectedValue(new Error("unexpected failure"));
+    });
+
+    it("redisDown=allow なら true を返す", async () => {
+      const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
+
+      expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
+    });
+
+    it("redisDown=deny なら false を返す", async () => {
+      const service = new ChannelConfigService(mockRepo, {
+        ...ALLOW_ALL,
+        redisDown: "deny",
+      });
+
+      expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
     });
   });
 
   describe("performHealthCheck", () => {
     it("リポジトリが performHealthCheck をサポートする場合その結果を返す", async () => {
-      const mockRepoWithHealthCheck = {
-        ...createMockRepo(),
-        performHealthCheck: vi.fn().mockResolvedValue(true),
-      };
-      const service = new loaded.ChannelConfigService(mockRepoWithHealthCheck);
+      const repo = { ...createMockRepo(), performHealthCheck: vi.fn().mockResolvedValue(true) };
+      const service = new ChannelConfigService(repo, ALLOW_ALL);
+
       expect(await service.performHealthCheck()).toBe(true);
     });
 
     it("performHealthCheck が false を返す場合 false を返す", async () => {
-      const mockRepoWithHealthCheck = {
-        ...createMockRepo(),
-        performHealthCheck: vi.fn().mockResolvedValue(false),
-      };
-      const service = new loaded.ChannelConfigService(mockRepoWithHealthCheck);
+      const repo = { ...createMockRepo(), performHealthCheck: vi.fn().mockResolvedValue(false) };
+      const service = new ChannelConfigService(repo, ALLOW_ALL);
+
       expect(await service.performHealthCheck()).toBe(false);
     });
 
     it("リポジトリが performHealthCheck をサポートしない場合 true を返す", async () => {
-      const service = new loaded.ChannelConfigService(mockRepo);
+      const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
+
       expect(await service.performHealthCheck()).toBe(true);
     });
-  });
-});
-
-// -------------------------
-// CONFIG_NOT_FOUND_FALLBACK=deny（明示的に制限する運用）
-// -------------------------
-describe("ChannelConfigService (CONFIG_NOT_FOUND_FALLBACK=deny)", () => {
-  let loaded: Awaited<ReturnType<typeof loadService>>;
-  let mockRepo: IChannelConfigRepository;
-
-  beforeAll(async () => {
-    vi.stubEnv("CONFIG_NOT_FOUND_FALLBACK", "deny");
-    loaded = await loadService();
-  });
-
-  afterAll(() => {
-    vi.unstubAllEnvs();
-  });
-
-  beforeEach(() => {
-    mockRepo = createMockRepo();
-  });
-
-  it("設定が見つからない場合 false を返す", async () => {
-    vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
-    const service = new loaded.ChannelConfigService(mockRepo);
-    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
-  });
-
-  it("Redis障害時は影響を受けず true を返す", async () => {
-    vi.mocked(mockRepo.getConfig).mockResolvedValue({
-      kind: "error",
-      error: new Error("redis down"),
-    });
-    const service = new loaded.ChannelConfigService(mockRepo);
-    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
-  });
-});
-
-// -------------------------
-// REDIS_DOWN_FALLBACK=deny（障害中も whitelist を維持する運用）
-// -------------------------
-describe("ChannelConfigService (REDIS_DOWN_FALLBACK=deny)", () => {
-  let loaded: Awaited<ReturnType<typeof loadService>>;
-  let mockRepo: IChannelConfigRepository;
-
-  beforeAll(async () => {
-    vi.stubEnv("REDIS_DOWN_FALLBACK", "deny");
-    loaded = await loadService();
-  });
-
-  afterAll(() => {
-    vi.unstubAllEnvs();
-  });
-
-  beforeEach(() => {
-    mockRepo = createMockRepo();
-  });
-
-  it("Redis障害時 false を返す", async () => {
-    vi.mocked(mockRepo.getConfig).mockResolvedValue({
-      kind: "error",
-      error: new Error("redis down"),
-    });
-    const service = new loaded.ChannelConfigService(mockRepo);
-    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
-  });
-
-  it("getConfig が例外を投げた場合 false を返す", async () => {
-    vi.mocked(mockRepo.getConfig).mockRejectedValue(
-      new Error("unexpected failure"),
-    );
-    const service = new loaded.ChannelConfigService(mockRepo);
-    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(false);
-  });
-
-  it("設定未作成時は影響を受けず true を返す", async () => {
-    vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
-    const service = new loaded.ChannelConfigService(mockRepo);
-    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
-  });
-});
-
-// -------------------------
-// 値の正規化（大文字・前後空白を許容する）
-// -------------------------
-describe("ChannelConfigService (値の正規化)", () => {
-  let loaded: Awaited<ReturnType<typeof loadService>>;
-
-  beforeAll(async () => {
-    vi.stubEnv("REDIS_DOWN_FALLBACK", " DENY ");
-    vi.stubEnv("CONFIG_NOT_FOUND_FALLBACK", "Deny");
-    loaded = await loadService();
-  });
-
-  afterAll(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it("大文字・前後空白を含む値も deny として解釈する", () => {
-    expect(loaded.getFallbackPolicy()).toEqual({
-      redisDown: "deny",
-      configNotFound: "deny",
-    });
-  });
-
-  it("正規化できた値に対しては警告を出さない", () => {
-    expect(
-      loaded.warnMessages.filter((message) => message.includes("Invalid")),
-    ).toHaveLength(0);
-  });
-});
-
-// -------------------------
-// 不正値（既定へ倒しつつ警告する）
-// -------------------------
-describe("ChannelConfigService (不正値)", () => {
-  let loaded: Awaited<ReturnType<typeof loadService>>;
-  let mockRepo: IChannelConfigRepository;
-
-  beforeAll(async () => {
-    vi.stubEnv("REDIS_DOWN_FALLBACK", "maybe");
-    loaded = await loadService();
-  });
-
-  afterAll(() => {
-    vi.unstubAllEnvs();
-  });
-
-  beforeEach(() => {
-    mockRepo = createMockRepo();
-  });
-
-  it("解釈できない値は既定の allow に倒す", () => {
-    expect(loaded.getFallbackPolicy().redisDown).toBe("allow");
-  });
-
-  it("解釈できない値を警告する", () => {
-    expect(
-      loaded.warnMessages.some(
-        (message) =>
-          message.includes("Invalid") &&
-          message.includes("REDIS_DOWN_FALLBACK") &&
-          message.includes("maybe"),
-      ),
-    ).toBe(true);
-  });
-
-  it("Redis障害時は既定どおり true を返す", async () => {
-    vi.mocked(mockRepo.getConfig).mockResolvedValue({
-      kind: "error",
-      error: new Error("redis down"),
-    });
-    const service = new loaded.ChannelConfigService(mockRepo);
-    expect(await service.isChannelAllowed("guild-1", "channel-1")).toBe(true);
   });
 });

--- a/tests/unit/core/ChannelConfigServiceAnnounceTarget.test.ts
+++ b/tests/unit/core/ChannelConfigServiceAnnounceTarget.test.ts
@@ -2,11 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GuildConfig, IChannelConfigRepository } from "@rx-twitter/shared";
 
+import type { FallbackPolicies } from "@/core/services/ChannelConfigService";
 import { ChannelConfigService } from "@/core/services/ChannelConfigService";
 
 vi.mock("@/utils/logger", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
+
+/** 配信先の解決はフォールバック方針に依存しないため、既定値を渡す */
+const ALLOW_ALL: FallbackPolicies = { redisDown: "allow", configNotFound: "allow" };
 
 const createMockRepo = (): IChannelConfigRepository => ({
   getConfig: vi.fn(),
@@ -35,7 +39,7 @@ describe("ChannelConfigService.getAnnounceTarget", () => {
       kind: "found",
       data: createGuildConfig({ announceTarget: { mode: "channel", channelId: "ch-1" } }),
     });
-    const service = new ChannelConfigService(mockRepo);
+    const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
 
     expect(await service.getAnnounceTarget("guild-1")).toEqual({ mode: "channel", channelId: "ch-1" });
   });
@@ -45,14 +49,14 @@ describe("ChannelConfigService.getAnnounceTarget", () => {
       kind: "found",
       data: createGuildConfig(),
     });
-    const service = new ChannelConfigService(mockRepo);
+    const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
 
     expect(await service.getAnnounceTarget("guild-1")).toEqual({ mode: "dm" });
   });
 
   it("設定が見つからない場合は DM デフォルトを返す", async () => {
     vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
-    const service = new ChannelConfigService(mockRepo);
+    const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
 
     expect(await service.getAnnounceTarget("guild-1")).toEqual({ mode: "dm" });
   });
@@ -64,14 +68,14 @@ describe("ChannelConfigService.getAnnounceTarget", () => {
         announceTarget: { mode: "invalid" as unknown as "dm" },
       }),
     });
-    const service = new ChannelConfigService(mockRepo);
+    const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
 
     expect(await service.getAnnounceTarget("guild-1")).toEqual({ mode: "dm" });
   });
 
   it("Redis 障害（error）の場合は DM デフォルトを返す", async () => {
     vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "error", error: new Error("redis down") });
-    const service = new ChannelConfigService(mockRepo);
+    const service = new ChannelConfigService(mockRepo, ALLOW_ALL);
 
     expect(await service.getAnnounceTarget("guild-1")).toEqual({ mode: "dm" });
   });


### PR DESCRIPTION
## 概要

`ChannelConfigService` がモジュールレベルで `process.env` を読んでいた。AGENTS.md のレイヤー原則「**Core** (`src/core/`): ビジネスロジック。外部依存ゼロ。Pure TypeScript」に反しており、「DI の配線は `src/index.ts` でのみ行う」というルールからも外れていた。

環境変数の解釈を `src/config/fallbackPolicy.ts` へ移し、解決した方針を `src/index.ts` から注入する。

Closes #560

**挙動変更はない。** 純粋なリファクタリング。

## 変更前

```typescript
// src/core/services/ChannelConfigService.ts
const REDIS_DOWN_FALLBACK = parseFallback(process.env.REDIS_DOWN_FALLBACK, "...");
const CONFIG_NOT_FOUND_FALLBACK = parseFallback(process.env.CONFIG_NOT_FOUND_FALLBACK, "...");

export class ChannelConfigService {
  constructor(private readonly repository: IChannelConfigRepository) {}
}
```

モジュール評価時に一度だけ解決されるため、環境変数を変えた検証には `vi.resetModules()` + 動的 import が必須だった。

## 変更後

```typescript
// src/core/services/ChannelConfigService.ts — 型だけを定義
export interface FallbackPolicies {
  redisDown: FallbackPolicy;
  configNotFound: FallbackPolicy;
}

export class ChannelConfigService {
  constructor(
    private readonly repository: IChannelConfigRepository,
    private readonly policies: FallbackPolicies   // 必須
  ) {}
}
```

```typescript
// src/config/fallbackPolicy.ts — 環境変数の解釈はここに集約
export const resolveFallbackPolicies = (env: NodeJS.ProcessEnv = process.env): FallbackPolicies => ({
  redisDown: parseFallback(env.REDIS_DOWN_FALLBACK, "REDIS_DOWN_FALLBACK"),
  configNotFound: parseFallback(env.CONFIG_NOT_FOUND_FALLBACK, "CONFIG_NOT_FOUND_FALLBACK"),
});
```

```typescript
// src/index.ts — 配線
const fallbackPolicies = resolveFallbackPolicies();
const channelConfigService = new ChannelConfigService(channelConfigRepository, fallbackPolicies);
```

### 設計判断

| 判断 | 理由 |
|---|---|
| `FallbackPolicies` の型は **Core** に置く | ドメインの語彙。config 側がそれを組み立てる形にすると、依存の向きが Core に向かう |
| **新規モジュール** `src/config/fallbackPolicy.ts` | `config.ts` は config.yml の読み込みとログ設定が責務で、import 時にファイル I/O を伴う。関心を混ぜない |
| `env` を**引数**で受け取る | テストから任意の環境を直接渡せる。`resetModules` が不要になる |
| 第2引数を**必須**にする | Core から隠れた既定値を完全に消す。配線を忘れれば型エラーで止まる |

## テストが素直になった

`tests/unit/core/ChannelConfigService.test.ts` から回避策が消えた。

```diff
-const loadService = async () => {
-  vi.resetModules();
-  const loggerModule = await import("@/utils/logger");
-  const service = await import("@/core/services/ChannelConfigService");
-  ...
-};
-  let ChannelConfigService: any;   // eslint-disable-line
+const service = new ChannelConfigService(mockRepo, { redisDown: "deny", configNotFound: "allow" });
```

方針を引数で渡せるため、1ファイル内で全組み合わせを検証できる。副次的に、**方針の独立性**を明示的にテストできるようになった。

- 「`redisDown` を `deny` にしても `not_found` の判定は変わらない」
- 「`configNotFound` を `deny` にしても `error` の判定は変わらない」

以前は環境変数ブロックごとにモジュールを読み直す構造だったため、この種の交差検証が書きにくかった。

## 検証

品質ゲート（AGENTS.md）:

- `npm run lint` — 警告/エラー ゼロ
- `npm run compile:test` / `npm run compile:tests` — 型エラー ゼロ
- `npm run build` — 正常完了
- `npm run test:unit` — **29 files / 368 tests passed**（365 + 新規 3、テストファイル 1 増）

Core の純粋性:

```bash
$ grep -rn "process.env" src/core/
（該当なし）
```

### 必須引数が未更新の箇所を検出した

第2引数を必須にしたことで、`compile:tests` が未更新の呼び出しを 6 箇所すべて止めた。

```
tests/e2e/channel-config.test.ts(27,23): error TS2554: Expected 2 arguments, but got 1.
tests/unit/core/ChannelConfigServiceAnnounceTarget.test.ts(42,21): error TS2554: ...
（他 4 箇所）
```

`tests/` が型チェック対象外だった頃（#562 以前）なら、e2e 側の呼び出しは実行時まで気づけなかった。

### ビルド済み成果物での確認

`dist/` を実際に実行し、環境変数を変えて注入経路を確認した。

```
--- 未設定 ---
RESULT 解決された方針: {"redisDown":"allow","configNotFound":"allow"}
RESULT env 由来の判定       : true
RESULT 直接注入(deny)の判定 : false

--- REDIS_DOWN_FALLBACK=deny ---
RESULT 解決された方針: {"redisDown":"deny","configNotFound":"allow"}
RESULT env 由来の判定       : false

--- REDIS_DOWN_FALLBACK=maybe ---
[WARN] [ChannelConfig] Invalid REDIS_DOWN_FALLBACK="maybe", falling back to "allow"
RESULT 解決された方針: {"redisDown":"allow","configNotFound":"allow"}
```

環境変数由来の方針と、直接注入した方針が独立して効いている。不正値の警告も従来どおり出る。

## 非スコープ

- フォールバックの既定値そのもの（#549 で決定済み、変更なし）
- 起動時ログの文言・レベル（変更なし。参照先が注入済みの値に変わっただけ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
