### PR TITLE
feat(config): GuildConfig に embedVersion を追加する（#548 の 1/4）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6105,7 +6105,7 @@
     },
     "packages/shared": {
       "name": "@rx-twitter/shared",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "6.0.3"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rx-twitter/shared",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Shared type definitions for TwitterRX Bot and Dashboard",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -5,6 +5,13 @@
 import type { AnnounceTarget } from "./announcement.js";
 
 /**
+ * 埋め込みの表示方式
+ * - v1: 従来の Embed
+ * - v2: Discord Components v2（Container 等で構成）
+ */
+export type EmbedVersion = "v1" | "v2";
+
+/**
  * Redisに保存されるギルド設定
  */
 export interface GuildConfig {
@@ -24,6 +31,8 @@ export interface GuildConfig {
   maxUrlsPerMessage?: number;
   /** お知らせの配信先設定（未設定時はBot側でオーナーへのDMをデフォルトとする） */
   announceTarget?: AnnounceTarget;
+  /** 埋め込みの表示方式（未設定時はBot側でデフォルトを使用） */
+  embedVersion?: EmbedVersion;
 }
 
 /**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -52,3 +52,6 @@ export const ANNOUNCEMENT_TITLE_MAX_LENGTH = 256;
 
 /** お知らせ本文の最大長（Discord Embed の説明文上限に準拠） */
 export const ANNOUNCEMENT_BODY_MAX_LENGTH = 4096;
+
+/** 埋め込み表示方式の既定値。guild 設定が無い場合に使用する */
+export const DEFAULT_EMBED_VERSION = "v2";

--- a/src/core/services/ChannelConfigService.ts
+++ b/src/core/services/ChannelConfigService.ts
@@ -1,5 +1,5 @@
-import type { AnnounceTarget, ConfigResult, IChannelConfigRepository } from "@rx-twitter/shared";
-import { DEFAULT_MAX_URLS_PER_MESSAGE, MAX_URLS_PER_MESSAGE_LIMIT } from "@rx-twitter/shared";
+import type { AnnounceTarget, ConfigResult, EmbedVersion, IChannelConfigRepository } from "@rx-twitter/shared";
+import { DEFAULT_EMBED_VERSION, DEFAULT_MAX_URLS_PER_MESSAGE, MAX_URLS_PER_MESSAGE_LIMIT } from "@rx-twitter/shared";
 
 import logger from "@/utils/logger";
 
@@ -128,6 +128,34 @@ export class ChannelConfigService {
     } catch (err) {
       logger.error(`[ChannelConfig] Unexpected error in getMaxUrlsPerMessage for guild ${guildId}:`, err);
       return DEFAULT_MAX_URLS_PER_MESSAGE;
+    }
+  }
+
+  /**
+   * 埋め込みの表示方式を取得する
+   *
+   * 未設定・不正値・設定未作成・Redis 障害時はいずれも既定（v2）へ倒す。
+   * 表示方式はチャンネル許可の可否とは独立した関心のため、
+   * フォールバック方針（FallbackPolicies）の影響を受けない。
+   */
+  async getEmbedVersion(guildId: string): Promise<EmbedVersion> {
+    try {
+      const result = await this.repository.getConfig(guildId);
+
+      if (result.kind !== "found") {
+        return DEFAULT_EMBED_VERSION;
+      }
+
+      const raw = result.data.embedVersion;
+
+      if (raw !== "v1" && raw !== "v2") {
+        return DEFAULT_EMBED_VERSION;
+      }
+
+      return raw;
+    } catch (err) {
+      logger.error(`[ChannelConfig] Unexpected error in getEmbedVersion for guild ${guildId}:`, err);
+      return DEFAULT_EMBED_VERSION;
     }
   }
 

--- a/tests/unit/core/ChannelConfigService.test.ts
+++ b/tests/unit/core/ChannelConfigService.test.ts
@@ -185,4 +185,66 @@ describe("ChannelConfigService", () => {
       expect(await service.performHealthCheck()).toBe(true);
     });
   });
+  describe("getEmbedVersion", () => {
+    const service = () => new ChannelConfigService(mockRepo, ALLOW_ALL);
+
+    it("設定があればその値を返す", async () => {
+      vi.mocked(mockRepo.getConfig).mockResolvedValue({
+        kind: "found",
+        data: createGuildConfig({ embedVersion: "v1" }),
+      });
+
+      expect(await service().getEmbedVersion("guild-1")).toBe("v1");
+    });
+
+    it("未設定なら既定の v2 を返す", async () => {
+      vi.mocked(mockRepo.getConfig).mockResolvedValue({
+        kind: "found",
+        data: createGuildConfig(),
+      });
+
+      expect(await service().getEmbedVersion("guild-1")).toBe("v2");
+    });
+
+    it("解釈できない値は既定の v2 に倒す", async () => {
+      vi.mocked(mockRepo.getConfig).mockResolvedValue({
+        kind: "found",
+        data: createGuildConfig({ embedVersion: "v3" as never }),
+      });
+
+      expect(await service().getEmbedVersion("guild-1")).toBe("v2");
+    });
+
+    it("設定が見つからない場合は既定の v2 を返す", async () => {
+      vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
+
+      expect(await service().getEmbedVersion("guild-1")).toBe("v2");
+    });
+
+    it("Redis 障害時も既定の v2 を返す", async () => {
+      vi.mocked(mockRepo.getConfig).mockResolvedValue({
+        kind: "error",
+        error: new Error("redis down"),
+      });
+
+      expect(await service().getEmbedVersion("guild-1")).toBe("v2");
+    });
+
+    it("フォールバック方針に関わらず既定は v2", async () => {
+      vi.mocked(mockRepo.getConfig).mockResolvedValue({ kind: "not_found" });
+      const denyService = new ChannelConfigService(mockRepo, {
+        redisDown: "deny",
+        configNotFound: "deny",
+      });
+
+      // チャンネル許可の方針と表示方式は独立した関心
+      expect(await denyService.getEmbedVersion("guild-1")).toBe("v2");
+    });
+
+    it("予期しない例外でも既定の v2 を返す", async () => {
+      vi.mocked(mockRepo.getConfig).mockRejectedValue(new Error("boom"));
+
+      expect(await service().getEmbedVersion("guild-1")).toBe("v2");
+    });
+  });
 });


### PR DESCRIPTION
## 概要

#548（埋め込み処理の Components v2 移行）の **1/4**。設定の器と取得経路のみを用意する。

**この時点では読み手が存在しないため、挙動は一切変わらない。**

Refs #548

## 分割方針

#548 は shared の型変更・新規 Builder・上限算出・送信分岐・owner コマンドが絡む規模のため、4 つの PR に分けて進める。1 つにまとめると、破壊的な振る舞い変更の差分が新規実装に埋もれてレビューが機能しなくなるため。

| # | 内容 | 破壊的 | 状態 |
|---|---|---|---|
| **1** | **`GuildConfig.embedVersion` を追加＋取得経路** | いいえ | **本 PR** |
| 2 | `premiumTier` 由来の動的添付上限 | **はい**（`feat!`） | 未着手 |
| 3 | `ComponentsV2Builder` ＋ 送信分岐（既定 v2） | **はい**（`feat!`） | 未着手 |
| 4 | owner コマンドに v1/v2 使用状況 | いいえ | 未着手 |

`feat!` を付けるのは 2 と 3。どちらかが `main` へ入った時点で `2.7.0` → `3.0.0` になる。**本 PR は破壊的変更ではないため `!` を付けていない。**

## 変更内容

### `packages/shared`

```typescript
/**
 * 埋め込みの表示方式
 * - v1: 従来の Embed
 * - v2: Discord Components v2（Container 等で構成）
 */
export type EmbedVersion = "v1" | "v2";

export interface GuildConfig {
  ...
  /** 埋め込みの表示方式（未設定時はBot側でデフォルトを使用） */
  embedVersion?: EmbedVersion;
}
```

```typescript
/** 埋め込み表示方式の既定値。guild 設定が無い場合に使用する */
export const DEFAULT_EMBED_VERSION = "v2";
```

### `ChannelConfigService.getEmbedVersion()`

既存の `getMaxUrlsPerMessage()` / `getAnnounceTarget()` と同じ形にした。未設定・不正値・設定未作成・Redis 障害のいずれも既定へ倒す。

### 設計判断: FallbackPolicies の影響を受けない

表示方式は**チャンネル許可の可否とは独立した関心**のため、`redisDown` / `configNotFound` の方針を参照しない。`deny` を明示した guild でも既定の `v2` を返す。

この独立性はテストで固定してある。

```typescript
it("フォールバック方針に関わらず既定は v2", async () => {
  const denyService = new ChannelConfigService(mockRepo, {
    redisDown: "deny", configNotFound: "deny",
  });
  // チャンネル許可の方針と表示方式は独立した関心
  expect(await denyService.getEmbedVersion("guild-1")).toBe("v2");
});
```

## shared のバージョン

`0.4.0` → **`0.5.0`**。フィールドの追加のみで既存の利用者に影響はないが、Dashboard が `embedVersion` を参照するには明示的なバージョン更新が必要になる。

Dashboard 側の切替 UI は #548 の非スコープで、companion issue（`rx-twitter/rx-twitter-dashboard#115`）で対応する。

## 検証

品質ゲート（AGENTS.md）:

- `npm run lint` / `compile:test` / `compile:tests` / `build`（`build:shared` 込み）— エラーゼロ
- `npm run test:unit` — **30 files / 394 tests passed**（387 + 新規 7）

### 実 Redis での確認

使い捨て Redis に 4 パターンの設定を書き込み、ビルド済み `dist/` から読み出した。

```
RESULT g-none     embedVersion=v2 isChannelAllowed=true   （未設定 → 既定）
RESULT g-v1       embedVersion=v1 isChannelAllowed=true   （明示）
RESULT g-bad      embedVersion=v2 isChannelAllowed=true   （不正値 "v9" → 既定）
RESULT g-missing  embedVersion=v2 isChannelAllowed=true   （設定なし → 既定）
```

既存の `isChannelAllowed` が従来どおり動作することも併せて確認している。

## 非スコープ

- 実際の v2 表示（PR 3）
- 添付上限の動的化（PR 2）
- owner コマンドでの使用状況表示（PR 4）
- Dashboard の切替 UI（別リポ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
