### PR TITLE
feat(discord): Components v2 のツイート表現を追加する（#548 の 3a）

### DIFF
--- a/src/adapters/discord/ComponentsV2Builder.ts
+++ b/src/adapters/discord/ComponentsV2Builder.ts
@@ -1,0 +1,159 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ContainerBuilder,
+  FileBuilder,
+  MediaGalleryBuilder,
+  MediaGalleryItemBuilder,
+  SectionBuilder,
+  SeparatorBuilder,
+  TextDisplayBuilder,
+} from "discord.js";
+
+import type { Tweet } from "@/core/models/Tweet";
+
+import { buildTweetBody, formatPollOptions, truncate } from "./tweetText";
+
+/** Embed と同じアクセントカラーを引き継ぐ */
+const ACCENT_COLOR = 9016025;
+
+/** Container 全体のテキスト上限。Discord の制約に合わせる */
+const MAX_BODY_LENGTH = 3000;
+
+/** 投票表示の上限 */
+const MAX_POLL_LENGTH = 1024;
+
+/** MediaGallery に載せる画像の上限 */
+const MAX_GALLERY_ITEMS = 10;
+
+export interface ComponentsV2Input {
+  tweet: Tweet;
+  /** 添付済み動画のファイル名（Container 内で attachment:// として参照する） */
+  attachedFileNames?: string[];
+  /** 上限を超えたためリンクで案内する動画URL */
+  oversizedVideoUrls?: string[];
+  /** ネタバレとして伏せるか */
+  spoiler?: boolean;
+}
+
+/**
+ * Discord Components v2 でのツイート表現を組み立てる
+ *
+ * 従来の Embed と異なり、動画を同じ Container 内に収められるため
+ * 別メッセージへの分離が不要になる。
+ */
+export class ComponentsV2Builder {
+  /**
+   * ツイートから Container を作成する
+   */
+  build(input: ComponentsV2Input): ContainerBuilder {
+    const { tweet, attachedFileNames = [], oversizedVideoUrls = [], spoiler = false } = input;
+
+    const container = new ContainerBuilder().setAccentColor(ACCENT_COLOR);
+
+    container.addSectionComponents(this.createHeader(tweet));
+
+    const body = truncate(buildTweetBody(tweet), MAX_BODY_LENGTH);
+    if (body !== "") {
+      container.addTextDisplayComponents(new TextDisplayBuilder().setContent(body));
+    }
+
+    if (tweet.poll && tweet.poll.options.length > 0) {
+      const poll = truncate(formatPollOptions(tweet.poll.options), MAX_POLL_LENGTH);
+      container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`### :bar_chart: poll\n${poll}`));
+    }
+
+    const gallery = this.createGallery(tweet, spoiler);
+    if (gallery) {
+      container.addMediaGalleryComponents(gallery);
+    }
+
+    for (const fileName of attachedFileNames) {
+      container.addFileComponents(new FileBuilder().setURL(`attachment://${fileName}`).setSpoiler(spoiler));
+    }
+
+    const linkRow = this.createOversizedVideoRow(oversizedVideoUrls);
+    if (linkRow) {
+      container.addActionRowComponents(linkRow);
+    }
+
+    container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
+    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(this.createMetrics(tweet)));
+
+    return container;
+  }
+
+  /**
+   * 著者情報とツイートへのリンク。アイコンはサムネイルとして添える
+   */
+  private createHeader(tweet: Tweet): SectionBuilder {
+    const title = tweet.article?.title ?? tweet.author.name;
+    const heading = `### [${title}](${tweet.url})\n[${tweet.author.name}](${tweet.author.url})`;
+
+    const section = new SectionBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(truncate(heading, MAX_POLL_LENGTH))
+    );
+
+    if (tweet.author.iconUrl) {
+      section.setThumbnailAccessory((thumbnail) => thumbnail.setURL(tweet.author.iconUrl));
+    }
+
+    return section;
+  }
+
+  /**
+   * 画像をギャラリーとしてまとめる
+   *
+   * 従来は同一URLの Embed を並べて Discord のギャラリー結合に頼っていたが、
+   * v2 では MediaGallery で明示的に表現できる。
+   */
+  private createGallery(tweet: Tweet, spoiler: boolean): MediaGalleryBuilder | undefined {
+    const urls = tweet.media.filter((m) => m.type === "photo").map((m) => m.thumbnailUrl);
+
+    if (tweet.article?.imageUrl) {
+      urls.unshift(tweet.article.imageUrl);
+    }
+
+    if (urls.length === 0) {
+      return undefined;
+    }
+
+    const items = urls
+      .slice(0, MAX_GALLERY_ITEMS)
+      .map((url) => new MediaGalleryItemBuilder().setURL(url).setSpoiler(spoiler));
+
+    return new MediaGalleryBuilder().addItems(...items);
+  }
+
+  /**
+   * 上限を超えた動画をリンクボタンとして並べる
+   */
+  private createOversizedVideoRow(urls: string[]): ActionRowBuilder<ButtonBuilder> | undefined {
+    if (urls.length === 0) {
+      return undefined;
+    }
+
+    const buttons = urls.slice(0, 5).map((url, index) =>
+      new ButtonBuilder()
+        .setStyle(ButtonStyle.Link)
+        .setURL(url)
+        .setLabel(urls.length === 1 ? "動画を開く" : `動画を開く (${index + 1})`)
+    );
+
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons);
+  }
+
+  /**
+   * メトリクスと投稿日時
+   */
+  private createMetrics(tweet: Tweet): string {
+    const unixSeconds = Math.floor(tweet.timestamp.getTime() / 1000);
+    return [
+      `:arrow_right_hook: ${tweet.metrics.replies}`,
+      `:hearts: ${tweet.metrics.likes}`,
+      `:arrows_counterclockwise: ${tweet.metrics.retweets}`,
+      `<t:${unixSeconds}:f>`,
+    ].join("　");
+  }
+}

--- a/src/adapters/discord/ComponentsV2Builder.ts
+++ b/src/adapters/discord/ComponentsV2Builder.ts
@@ -50,9 +50,11 @@ export class ComponentsV2Builder {
   build(input: ComponentsV2Input): ContainerBuilder {
     const { tweet, attachedFileNames = [], oversizedVideoUrls = [], spoiler = false } = input;
 
-    const container = new ContainerBuilder().setAccentColor(ACCENT_COLOR);
+    // スポイラーは Container 全体へ適用する。MediaGallery / File だけに
+    // 立てると、テキストのみのツイートで指定が消える
+    const container = new ContainerBuilder().setAccentColor(ACCENT_COLOR).setSpoiler(spoiler);
 
-    container.addSectionComponents(this.createHeader(tweet));
+    this.addHeader(container, tweet);
 
     const body = truncate(buildTweetBody(tweet), MAX_BODY_LENGTH);
     if (body !== "") {
@@ -85,21 +87,30 @@ export class ComponentsV2Builder {
   }
 
   /**
-   * 著者情報とツイートへのリンク。アイコンはサムネイルとして添える
+   * 著者情報とツイートへのリンクを追加する
+   *
+   * アイコンがあれば Section のサムネイルとして添える。Section の accessory は
+   * 必須で、持たない Section は toJSON() が CombinedError を投げるため、
+   * アイコンが無い場合は通常の TextDisplay として追加する。
+   * FxTwitter の avatar_url は nullable で、Adapter が空文字へ変換するため到達しうる。
    */
-  private createHeader(tweet: Tweet): SectionBuilder {
+  private addHeader(container: ContainerBuilder, tweet: Tweet): void {
     const title = tweet.article?.title ?? tweet.author.name;
-    const heading = `### [${title}](${tweet.url})\n[${tweet.author.name}](${tweet.author.url})`;
-
-    const section = new SectionBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(truncate(heading, MAX_POLL_LENGTH))
+    const heading = truncate(
+      `### [${title}](${tweet.url})\n[${tweet.author.name}](${tweet.author.url})`,
+      MAX_POLL_LENGTH
     );
 
-    if (tweet.author.iconUrl) {
-      section.setThumbnailAccessory((thumbnail) => thumbnail.setURL(tweet.author.iconUrl));
+    if (!tweet.author.iconUrl) {
+      container.addTextDisplayComponents(new TextDisplayBuilder().setContent(heading));
+      return;
     }
 
-    return section;
+    container.addSectionComponents(
+      new SectionBuilder()
+        .addTextDisplayComponents(new TextDisplayBuilder().setContent(heading))
+        .setThumbnailAccessory((thumbnail) => thumbnail.setURL(tweet.author.iconUrl))
+    );
   }
 
   /**

--- a/src/adapters/discord/EmbedBuilder.ts
+++ b/src/adapters/discord/EmbedBuilder.ts
@@ -2,17 +2,17 @@ import { APIEmbedField, EmbedBuilder } from "discord.js";
 
 import { Tweet, TweetPollOption } from "@/core/models/Tweet";
 
+import { buildTweetBody, formatPollOptions, truncate } from "./tweetText";
+
 /**
  * Discord Embed作成を担当
  */
 export class DiscordEmbedBuilder {
   private readonly embedColor = 9016025;
-  private readonly quotePrefix = "QT: ";
   private readonly br = "\n";
   private readonly maxTitleLength = 256;
   private readonly maxDescriptionLength = 4096;
   private readonly maxPollFieldLength = 1024;
-  private readonly articleOnlyPattern = /^https?:\/\/(?:www\.)?(?:x|twitter)\.com\/i\/article\/[0-9]+(?:[?#]\S*)?$/;
 
   /**
    * ツイートからDiscord Embedを作成
@@ -65,23 +65,11 @@ export class DiscordEmbedBuilder {
       embed.addFields(this.createPollField(tweet.poll.options));
     }
 
-    // 説明文の作成（引用ツイート情報を含む）
-    const tweetText = tweet.article && this.articleOnlyPattern.test(tweet.text.trim()) ? "" : tweet.text;
-    let description = this.convertMentionsToLinks(tweetText);
-    if (tweet.article) {
-      description +=
-        (description === "" ? "" : this.br + this.br) + this.convertMentionsToLinks(tweet.article.previewText);
-    }
-    if (tweet.quote) {
-      const quoteAuthorLink = this.createMentionLink(tweet.quote.author.id);
-      const quoteTextWithLinks = this.convertMentionsToLinks(tweet.quote.text);
-      const quoteText = this.quotePrefix + quoteAuthorLink + " " + quoteTextWithLinks;
-      const quoteUrl = "(" + tweet.quote.url + ")";
-      description += this.br + this.br + quoteText + this.br + quoteUrl;
-    }
+    // 説明文の作成（引用ツイート情報を含む）。整形ロジックは v2 と共有する
+    const description = buildTweetBody(tweet);
 
     if (description !== "") {
-      embed.setDescription(this.truncateDescription(description));
+      embed.setDescription(truncate(description, this.maxDescriptionLength));
     }
 
     return embed;
@@ -91,10 +79,7 @@ export class DiscordEmbedBuilder {
    * Embedタイトルを最大長に収める（超過時は末尾を省略）
    */
   private truncateTitle(text: string): string {
-    if (text.length <= this.maxTitleLength) {
-      return text;
-    }
-    return text.substring(0, this.maxTitleLength - 3) + "...";
+    return truncate(text, this.maxTitleLength);
   }
 
   /**
@@ -117,72 +102,10 @@ export class DiscordEmbedBuilder {
    * @returns APIEmbedField
    */
   private createPollField(options: TweetPollOption[]): APIEmbedField {
-    const value = options
-      .map((option, index) => {
-        return `${index + 1}. ${option.label} — ${option.votes} votes (${option.percentage}%)`;
-      })
-      .join(this.br);
-
     return {
       inline: false,
       name: ":bar_chart: poll",
-      value: this.truncatePollField(value),
+      value: truncate(formatPollOptions(options), this.maxPollFieldLength),
     };
-  }
-
-  /**
-   * ＠メンションをクリック可能なリンクに変換
-   * @param text 変換対象のテキスト
-   * @returns ＠メンションがリンク化されたテキスト
-   */
-  private convertMentionsToLinks(text: string): string {
-    // URL部分を一時的に抽出してプレースホルダーに置換
-    const urlPattern = /https?:\/\/[^\s]+/g;
-    const urls: string[] = [];
-    const textWithPlaceholders = text.replace(urlPattern, (url) => {
-      urls.push(url);
-      return `__URL_PLACEHOLDER_${urls.length - 1}__`;
-    });
-
-    // @メンションをマークダウンリンクに変換（連続する@の最後のみ変換、全角@にも対応）
-    const transformed = textWithPlaceholders.replace(/([@＠]*)[@＠]([A-Za-z0-9_]{1,15})\b/g, (_, prefix, username) => {
-      return prefix + this.createMentionLink(username);
-    });
-
-    // プレースホルダーを元のURLに戻す
-    return transformed.replace(/__URL_PLACEHOLDER_(\d+)__/g, (_, index) => urls[parseInt(index)]);
-  }
-
-  /**
-   * ユーザー名のMarkdown装飾を無効化したリンクを作成
-   * @param username Xのユーザー名
-   * @returns ユーザーページへのMarkdownリンク
-   */
-  private createMentionLink(username: string): string {
-    return `[\`@${username}\`](https://x.com/${username})`;
-  }
-
-  /**
-   * 説明文を最大長に収める（超過時は末尾を省略）
-   * @param text 説明文
-   * @returns 切り詰められた説明文
-   */
-  private truncateDescription(text: string): string {
-    if (text.length <= this.maxDescriptionLength) {
-      return text;
-    }
-    return text.substring(0, this.maxDescriptionLength - 3) + "...";
-  }
-
-  /**
-   * 投票フィールドを最大長に収める（超過時は末尾を省略）
-   * @param text 投票フィールドの文字列
-   * @returns 切り詰められた投票フィールド
-   */
-  private truncatePollField(text: string): string {
-    if (text.length <= this.maxPollFieldLength) {
-      return text;
-    }
-    return text.substring(0, this.maxPollFieldLength - 3) + "...";
   }
 }

--- a/src/adapters/discord/tweetText.ts
+++ b/src/adapters/discord/tweetText.ts
@@ -1,0 +1,75 @@
+import type { Tweet, TweetPollOption } from "@/core/models/Tweet";
+
+/** 引用ツイートの接頭辞 */
+export const QUOTE_PREFIX = "QT: ";
+
+/** 本文が記事本体URLのみで構成されているかの判定 */
+const ARTICLE_ONLY_PATTERN = /^https?:\/\/(?:www\.)?(?:x|twitter)\.com\/i\/article\/[0-9]+(?:[?#]\S*)?$/;
+
+/**
+ * ユーザー名のMarkdown装飾を無効化したリンクを作成
+ * @param username Xのユーザー名
+ */
+export const createMentionLink = (username: string): string => `[\`@${username}\`](https://x.com/${username})`;
+
+/**
+ * ＠メンションをクリック可能なリンクに変換
+ *
+ * URL 内の @ を誤変換しないよう、URL を一旦プレースホルダへ退避してから置換する。
+ * @param text 変換対象のテキスト
+ */
+export const convertMentionsToLinks = (text: string): string => {
+  const urlPattern = /https?:\/\/[^\s]+/g;
+  const urls: string[] = [];
+  const textWithPlaceholders = text.replace(urlPattern, (url) => {
+    urls.push(url);
+    return `__URL_PLACEHOLDER_${urls.length - 1}__`;
+  });
+
+  // 連続する@の最後のみ変換（全角＠にも対応）
+  const transformed = textWithPlaceholders.replace(/([@＠]*)[@＠]([A-Za-z0-9_]{1,15})\b/g, (_, prefix, username) => {
+    return prefix + createMentionLink(username);
+  });
+
+  return transformed.replace(/__URL_PLACEHOLDER_(\d+)__/g, (_, index) => urls[parseInt(index)]);
+};
+
+/**
+ * 末尾を省略して最大長に収める
+ */
+export const truncate = (text: string, maxLength: number): string => {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.substring(0, maxLength - 3) + "...";
+};
+
+/**
+ * 投票の選択肢を行テキストへ整形
+ */
+export const formatPollOptions = (options: TweetPollOption[]): string =>
+  options
+    .map((option, index) => `${index + 1}. ${option.label} — ${option.votes} votes (${option.percentage}%)`)
+    .join("\n");
+
+/**
+ * ツイート本文を組み立てる（メンションのリンク化・記事プレビュー・引用を含む）
+ *
+ * 本文が記事本体URLのみの場合は本文を空として扱い、記事プレビューのみを表示する。
+ */
+export const buildTweetBody = (tweet: Tweet): string => {
+  const tweetText = tweet.article && ARTICLE_ONLY_PATTERN.test(tweet.text.trim()) ? "" : tweet.text;
+  let body = convertMentionsToLinks(tweetText);
+
+  if (tweet.article) {
+    body += (body === "" ? "" : "\n\n") + convertMentionsToLinks(tweet.article.previewText);
+  }
+
+  if (tweet.quote) {
+    const quoteAuthorLink = createMentionLink(tweet.quote.author.id);
+    const quoteTextWithLinks = convertMentionsToLinks(tweet.quote.text);
+    body += "\n\n" + QUOTE_PREFIX + quoteAuthorLink + " " + quoteTextWithLinks + "\n(" + tweet.quote.url + ")";
+  }
+
+  return body;
+};

--- a/tests/unit/adapters/discord/ComponentsV2Builder.test.ts
+++ b/tests/unit/adapters/discord/ComponentsV2Builder.test.ts
@@ -133,4 +133,48 @@ describe("ComponentsV2Builder", () => {
       expect(json).toContain("はい");
     });
   });
+  describe("スポイラー", () => {
+    it("Container 全体にスポイラーを適用する", () => {
+      const json = buildJson({ tweet: createMockTweet(), spoiler: true });
+
+      expect(json.spoiler).toBe(true);
+    });
+
+    it("テキストのみのツイートでもスポイラーが残る", () => {
+      // メディアが無い場合、MediaGallery / File が作られないため
+      // それらにしかフラグを立てないと spoiler 指定が消える
+      const json = buildJson({ tweet: createMockTweet({ media: [] }), spoiler: true });
+
+      expect(json.spoiler).toBe(true);
+    });
+
+    it("spoiler 未指定なら伏せない", () => {
+      const json = buildJson({ tweet: createMockTweet() });
+
+      expect(json.spoiler ?? false).toBe(false);
+    });
+  });
+
+  describe("著者アイコンが無い場合", () => {
+    // FxTwitterAdapter は avatar_url が null のとき空文字へ変換するため到達しうる
+    const noIcon = () => createMockTweet({ author: { ...createMockTweet().author, iconUrl: "" } });
+
+    it("シリアライズできる", () => {
+      // accessory を持たない Section は toJSON() で CombinedError を投げる
+      expect(() => buildJson({ tweet: noIcon() })).not.toThrow();
+    });
+
+    it("著者名は失われない", () => {
+      const json = buildJson({ tweet: noIcon() });
+
+      expect(allText(json)).toContain(noIcon().author.name);
+    });
+
+    it("Section を使わずヘッダを表現する", () => {
+      const json = buildJson({ tweet: noIcon() });
+
+      expect(componentsOf(json, ComponentType.Section)).toHaveLength(0);
+      expect(componentsOf(json, ComponentType.TextDisplay).length).toBeGreaterThanOrEqual(2);
+    });
+  });
 });

--- a/tests/unit/adapters/discord/ComponentsV2Builder.test.ts
+++ b/tests/unit/adapters/discord/ComponentsV2Builder.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { ComponentType } from "discord.js";
+
+import { ComponentsV2Builder } from "@/adapters/discord/ComponentsV2Builder";
+import { createMockTweet } from "../../../fixtures/mock-tweets";
+
+const builder = new ComponentsV2Builder();
+
+/** Container の JSON から指定種別のコンポーネントを集める */
+const componentsOf = (json: ReturnType<ReturnType<ComponentsV2Builder["build"]>["toJSON"]>, type: ComponentType) =>
+  (json.components ?? []).filter((c) => c.type === type);
+
+const buildJson = (input: Parameters<ComponentsV2Builder["build"]>[0]) => builder.build(input).toJSON();
+
+const allText = (json: ReturnType<typeof buildJson>) => JSON.stringify(json);
+
+describe("ComponentsV2Builder", () => {
+  it("Container として組み立てる", () => {
+    const json = buildJson({ tweet: createMockTweet() });
+
+    expect(json.type).toBe(ComponentType.Container);
+    expect(json.accent_color).toBe(9016025);
+  });
+
+  it("著者情報を Section のヘッダに含める", () => {
+    const tweet = createMockTweet();
+    const json = buildJson({ tweet });
+
+    const sections = componentsOf(json, ComponentType.Section);
+    expect(sections).toHaveLength(1);
+    expect(JSON.stringify(sections[0])).toContain(tweet.author.name);
+    expect(JSON.stringify(sections[0])).toContain(tweet.url);
+  });
+
+  it("本文とメトリクスを TextDisplay として持つ", () => {
+    const tweet = createMockTweet({ text: "hello world" });
+    const json = buildJson({ tweet });
+
+    const texts = componentsOf(json, ComponentType.TextDisplay);
+    expect(texts.length).toBeGreaterThanOrEqual(2);
+    expect(allText(json)).toContain("hello world");
+    expect(allText(json)).toContain(String(tweet.metrics.likes));
+  });
+
+  it("区切りを入れる", () => {
+    const json = buildJson({ tweet: createMockTweet() });
+
+    expect(componentsOf(json, ComponentType.Separator)).toHaveLength(1);
+  });
+
+  describe("画像", () => {
+    it("複数の画像を1つの MediaGallery にまとめる", () => {
+      const tweet = createMockTweet({
+        media: [
+          { url: "https://example.test/1.jpg", thumbnailUrl: "https://example.test/1.jpg", type: "photo" },
+          { url: "https://example.test/2.jpg", thumbnailUrl: "https://example.test/2.jpg", type: "photo" },
+        ],
+      });
+
+      const galleries = componentsOf(buildJson({ tweet }), ComponentType.MediaGallery);
+      expect(galleries).toHaveLength(1);
+      expect(JSON.stringify(galleries[0])).toContain("1.jpg");
+      expect(JSON.stringify(galleries[0])).toContain("2.jpg");
+    });
+
+    it("画像が無ければ MediaGallery を作らない", () => {
+      const json = buildJson({ tweet: createMockTweet({ media: [] }) });
+
+      expect(componentsOf(json, ComponentType.MediaGallery)).toHaveLength(0);
+    });
+
+    it("spoiler 指定でぼかしフラグを立てる", () => {
+      const tweet = createMockTweet({
+        media: [{ url: "https://example.test/1.jpg", thumbnailUrl: "https://example.test/1.jpg", type: "photo" }],
+      });
+
+      const json = buildJson({ tweet, spoiler: true });
+      expect(JSON.stringify(componentsOf(json, ComponentType.MediaGallery))).toContain('"spoiler":true');
+    });
+  });
+
+  describe("動画", () => {
+    it("添付済み動画を attachment:// で Container 内に含める", () => {
+      const json = buildJson({ tweet: createMockTweet(), attachedFileNames: ["output1.mp4"] });
+
+      const files = componentsOf(json, ComponentType.File);
+      expect(files).toHaveLength(1);
+      expect(JSON.stringify(files[0])).toContain("attachment://output1.mp4");
+    });
+
+    it("上限超過の動画はリンクボタンにする", () => {
+      const json = buildJson({
+        tweet: createMockTweet(),
+        oversizedVideoUrls: ["https://video.example.test/big.mp4"],
+      });
+
+      const rows = componentsOf(json, ComponentType.ActionRow);
+      expect(rows).toHaveLength(1);
+      expect(JSON.stringify(rows[0])).toContain("https://video.example.test/big.mp4");
+      expect(JSON.stringify(rows[0])).toContain("動画を開く");
+    });
+
+    it("超過動画が無ければボタン行を作らない", () => {
+      const json = buildJson({ tweet: createMockTweet() });
+
+      expect(componentsOf(json, ComponentType.ActionRow)).toHaveLength(0);
+    });
+  });
+
+  describe("引用・投票", () => {
+    it("引用ツイートを本文に含める", () => {
+      const tweet = createMockTweet({
+        quote: {
+          url: "https://x.com/quoted/status/999",
+          text: "quoted body",
+          author: { id: "quoted_user", name: "Quoted", url: "https://x.com/quoted", iconUrl: "" },
+          media: [],
+          metrics: { replies: 0, likes: 0, retweets: 0 },
+          timestamp: new Date(),
+        } as never,
+      });
+
+      expect(allText(buildJson({ tweet }))).toContain("quoted body");
+    });
+
+    it("投票を含める", () => {
+      const tweet = createMockTweet({
+        poll: { options: [{ label: "はい", votes: 3, percentage: 75 }] } as never,
+      });
+
+      const json = allText(buildJson({ tweet }));
+      expect(json).toContain("poll");
+      expect(json).toContain("はい");
+    });
+  });
+});


### PR DESCRIPTION
## 概要

#548（埋め込み処理の Components v2 移行）の **3a**。`ComponentsV2Builder` を新設する。

**この時点では呼び出し元が存在しないため、挙動は変わらない。** 送信分岐は 3b で行う。

Refs #548

## PR 3 を 3a / 3b に分けた理由

当初 4 分割で合意していたが、PR 3（v2 本体）は Builder の新規実装と送信分岐の両方を含み、単独でも大きい。分けた理由は 2 つ。

- **Builder 単体なら挙動を変えずに検証できる**。JSON 構造の妥当性をレビューで確認してから配線に進める
- **破壊的な差分を小さく保てる**。3b は「どちらを呼ぶか」の分岐だけになり、既定 v2 への切替という一番慎重に見るべき箇所が新規実装に埋もれない

PR 1 で採った「先に眠らせて、後で起こす」と同じ形。

| # | 内容 | 破壊的 | 状態 |
|---|---|---|---|
| 1 | `GuildConfig.embedVersion` ＋ 取得経路 | いいえ | #579 |
| 2 | `premiumTier` 由来の動的添付上限 | **はい** | #580 |
| **3a** | **`ComponentsV2Builder` の新設** | **いいえ** | **本 PR** |
| 3b | 送信分岐（既定 v2・動画同梱・スポイラー） | **はい** | 未着手 |
| 4 | owner コマンドに v1/v2 使用状況 | いいえ | 未着手 |

## テキスト整形を共有モジュールへ抽出した

メンションのリンク化・引用の組み立て・投票の整形・切り詰めは `DiscordEmbedBuilder` の private に閉じていた。v2 でも同じ整形が要る。

**重複させると必ず片方だけ修正されて表示が割れる**ため、最初から `tweetText.ts` に抽出して両者から使う形にした。

```typescript
export const convertMentionsToLinks = (text: string): string => { ... };
export const buildTweetBody = (tweet: Tweet): string => { ... };
export const formatPollOptions = (options: TweetPollOption[]): string => { ... };
export const truncate = (text: string, maxLength: number): string => { ... };
```

`DiscordEmbedBuilder` はこれらを使う形へ置き換え、**91 行のうち大半を削除**した。

**既存の 387 件がそのまま通ることで、v1 の出力が変わっていないことを確認している。**

## Container の構成

```
Container (accent: 9016025 — Embed と同じ色)
  ├ Section        著者名・タイトル・ツイートURL（アイコンをサムネイル）
  ├ TextDisplay    本文（メンションリンク・記事プレビュー・引用）
  ├ TextDisplay    投票
  ├ MediaGallery   画像
  ├ File           動画（attachment:// 参照）
  ├ ActionRow      上限超過の動画をリンクボタンで案内
  ├ Separator
  └ TextDisplay    メトリクス + 投稿日時
```

- **複数画像を MediaGallery でまとめる。** 従来の「同一 URL の Embed を並べて Discord のギャラリー結合に頼る」ハックが不要になる
- **動画を同じ Container 内に収める。** 別メッセージへの分離が不要になる（#548 の主目的）
- `spoiler` 指定で MediaGallery と File にぼかしフラグを立てる

## 検証

品質ゲート（AGENTS.md）:

- `npm run lint` / `compile:test` / `compile:tests` / `build` — エラーゼロ
- `npm run test:unit` — **31 files / 399 tests passed**（387 + 新規 12、テストファイル 1 増）

### ビルド済み成果物での確認

実際に送信ペイロードの形まで組み立てた。

```
RESULT flags = 32768 (IsComponentsV2 = 32768)
RESULT Container 内の component type: [9,10,12,13,1,14,10]
RESULT JSON バイト数: 802
RESULT v1 の Embed 数（同じツイート）: 2
RESULT メンションのリンク化: true
RESULT URL が壊れていない: true
```

`[9,10,12,13,1,14,10]` は Section / TextDisplay / MediaGallery / File / ActionRow / Separator / TextDisplay。

**同じツイートで v1 は Embed 2 個に分裂するのに対し、v2 は Container 1 つに収まっている。** 画像 2 枚を同一 URL の Embed で並べる必要がなくなったため。

### 追加したテスト

`tests/unit/adapters/discord/ComponentsV2Builder.test.ts`（12 件）。Container の型・アクセントカラー、著者ヘッダ、本文とメトリクス、区切り、画像の MediaGallery 統合、画像なし時の非生成、spoiler フラグ、動画の `attachment://` 参照、超過動画のリンクボタン、引用、投票を固定。

## 未確認

実際の Discord 上での見た目は確認していない。Bot トークンが必要なため。3b で配線したのち、実サーバーでの確認をお願いしたい。

## 非スコープ

- 送信分岐と既定 v2 への切替（3b）
- owner コマンドでの使用状況表示（PR 4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
