### PR TITLE
fix(discord): アイコン未設定のツイートが展開されない問題を修正する

### DIFF
--- a/src/adapters/discord/EmbedBuilder.ts
+++ b/src/adapters/discord/EmbedBuilder.ts
@@ -42,10 +42,13 @@ export class DiscordEmbedBuilder {
    */
   private createSingleEmbed(tweet: Tweet): EmbedBuilder {
     const embed = new EmbedBuilder()
+      // iconURL は「未指定」か「有効なURL」のみを受け付ける。
+      // 空文字を渡すと例外になるため、無い場合はキー自体を含めない。
+      // FxTwitter の avatar_url は nullable で、Adapter が空文字へ変換するため到達しうる。
       .setAuthor({
         name: tweet.author.name,
         url: tweet.author.url,
-        iconURL: tweet.author.iconUrl,
+        ...(tweet.author.iconUrl ? { iconURL: tweet.author.iconUrl } : {}),
       })
       .setTitle(this.truncateTitle(tweet.article?.title ?? tweet.author.name))
       .setURL(tweet.url)

--- a/tests/unit/adapters/discord/EmbedBuilder.test.ts
+++ b/tests/unit/adapters/discord/EmbedBuilder.test.ts
@@ -323,4 +323,35 @@ describe("DiscordEmbedBuilder", () => {
       expect(embedData.description).toContain("＠[`@test`](https://x.com/test)");
     });
   });
+  describe("著者アイコンが無い場合", () => {
+    // FxTwitter の avatar_url は nullable で、FxTwitterAdapter が空文字へ変換するため到達しうる
+    const noIcon = () => createMockTweet({ author: { ...createMockTweet().author, iconUrl: "" } });
+
+    it("例外を投げずに Embed を生成できる", () => {
+      // setAuthor の iconURL は「未指定」か「有効なURL」のみを受け付ける。
+      // 空文字を渡すと ValidationError と Invalid URL の両方で弾かれる
+      expect(() => builder.build(noIcon())).not.toThrow();
+    });
+
+    it("著者名とリンクは失われない", () => {
+      const [embed] = builder.build(noIcon());
+      const json = embed.toJSON();
+
+      expect(json.author?.name).toBe(noIcon().author.name);
+      expect(json.author?.url).toBe(noIcon().author.url);
+    });
+
+    it("iconURL を渡さない", () => {
+      const [embed] = builder.build(noIcon());
+
+      expect(embed.toJSON().author?.icon_url).toBeUndefined();
+    });
+
+    it("アイコンがあれば従来どおり設定する", () => {
+      const tweet = createMockTweet();
+      const [embed] = builder.build(tweet);
+
+      expect(embed.toJSON().author?.icon_url).toBe(tweet.author.iconUrl);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

著者のアイコンが未設定のツイートが**まったく展開されない**状態だった。`EmbedBuilder.setAuthor()` の `iconURL` は「未指定」か「有効な URL」のみを受け付けるため、空文字で例外になる。

Closes #583

## 再現

```
CombinedPropertyError: Received one or more errors
  at EmbedBuilder.setAuthor (@discordjs/builders/dist/index.js:311:26)
  at DiscordEmbedBuilder.createSingleEmbed (dist/adapters/discord/EmbedBuilder.js:38:14)
  errors: [['iconURL', [
    ValidationError: Expected undefined or null   (validator: 's.nullish()', given: '')
    ExpectedConstraintError: Invalid URL          (constraint: 's.string().url()', given: '')
  ]]]
```

例外は `MessageHandler.ts:206` の catch まで伝播し、ログを残して終わる。**利用者にはエラーも案内も表示されず、何も起きないように見える。**

## 到達経路

`src/adapters/twitter/FxTwitterAdapter.ts:112`

```typescript
author: this.createAuthor(..., author.avatar_url ?? ""),
```

FxTwitter の `avatar_url` は nullable。null が空文字へ変換され、そのまま `setAuthor` に渡る。

VxTwitter は `user_profile_image_url` が必須の `string` のため、**Vx が失敗して Fx へフォールバックしたときのみ顕在化する**。primary が正常なうちは表に出ないが、フォールバックはまさに障害時に効いてほしい経路である。

## 変更内容

`iconUrl` が空の場合はキー自体を含めない。

```typescript
// iconURL は「未指定」か「有効なURL」のみを受け付ける。
// 空文字を渡すと例外になるため、無い場合はキー自体を含めない。
.setAuthor({
  name: tweet.author.name,
  url: tweet.author.url,
  ...(tweet.author.iconUrl ? { iconURL: tweet.author.iconUrl } : {}),
})
```

## 発見の経緯

#548 の実サーバー表示確認スクリプトで、v1 と v2 を並べて送ろうとした際に v1 側が落ちて判明した。

#581 のレビューで「アイコンが無いと `Section` の `toJSON()` が `CombinedError` を投げる」という指摘を受け v2 側は修正済みだったが、**同じ入力が v1 でも壊れることには気づいていなかった**。指摘された箇所だけを見て、指摘の射程を確かめていなかった。

ユニットテストが捕まえられなかったのは、v1 と v2 を別々に検証しており、**同じ入力を両方に通す観点が無かった**ため。

## 検証

品質ゲート（AGENTS.md）:

- `npm run lint` / `compile:test` / `compile:tests` / `build` — エラーゼロ
- `npm run test:unit` — **32 files / 431 tests passed**（新規 4）

ビルド済み成果物で v1 / v2 の両方を通した。

```
RESULT アイコンあり  v1=成功 icon_url="https://example.test/i.jpg"  v2=成功
RESULT アイコンなし  v1=成功 icon_url=undefined                    v2=成功
```

### 追加したテスト

| テスト | 検証内容 |
|---|---|
| 例外を投げずに Embed を生成できる | `build()` が throw しないこと |
| 著者名とリンクは失われない | `author.name` / `author.url` が残ること |
| `iconURL` を渡さない | `author.icon_url` が `undefined` であること |
| アイコンがあれば従来どおり設定する | 回帰検知 |

## 非スコープ

- `FxTwitterAdapter` の `?? ""` 変換そのものの見直し。`Tweet.author.iconUrl` を省略可能にすれば「無い」ことを空文字で表現する必要がなくなるが、影響範囲が広いため別途判断する（#583 に記載）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
