### PR TITLE
feat(test): Bot の主要フローを通す E2E テストを再導入する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,13 +159,13 @@ jobs:
       - name: Build shared package
         run: npm run build:shared
 
-      # tests/integration のテストは全て明示フラグでゲートされているため、
-      # ディレクトリ指定でよい。RUN_REDIS_INTEGRATION だけを立てるので、
+      # tests/integration と tests/e2e のテストは全て明示フラグでゲートされて
+      # いるため、ディレクトリ指定でよい。RUN_REDIS_INTEGRATION だけを立てるので、
       # 実 API を叩くテスト（RUN_LIVE_API_TESTS）は skipped のまま残る。
       # ファイル名を列挙しないことで、テスト追加時に CI への追記を忘れても
       # 実行対象から漏れない。
-      - name: Run Redis integration tests
-        run: npx vitest run tests/integration
+      - name: Run Redis integration and E2E tests
+        run: npx vitest run tests/integration tests/e2e
         env:
           RUN_REDIS_INTEGRATION: "1"
           REDIS_URL: redis://localhost:6379

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ src/
 tests/
 ├── unit/               # 単体テスト（モック使用）
 ├── integration/        # 結合テスト（実 Redis / 実 API を使うものは明示フラグでオプトイン）
+├── e2e/                # Bot の主要フローを通すテスト（Discord と fetch のみ差し替え）
 └── fixtures/           # テストフィクスチャ
 packages/
 └── shared/             # Bot・Dashboard 共通パッケージ @twitterrx/shared
@@ -189,7 +190,15 @@ scope は省略可能。description は日本語でも英語でもよいが、�
 
 - **未実行を成功扱いにしない**: 依存が無いときに `if (!available) return;` で早期 return すると、テストが緑のまま何も検証しない。依存の有無は `skipIf` で表明し、実行されなかったことがレポートに `skipped` として残るようにする。
 
-- `tests/integration/` に置くテストは**必ずいずれかのフラグでゲートする**。ゲートの無いテストを置くと、通常の `test` ジョブ（`npm run test:coverage`）が外部依存を巻き込んで不安定になる。外部依存の要らないテストは `tests/unit/` に置く。
+- `tests/integration/` と `tests/e2e/` に置くテストは**必ずいずれかのフラグでゲートする**。ゲートの無いテストを置くと、通常の `test` ジョブ（`npm run test:coverage`）が外部依存を巻き込んで不安定になる。外部依存の要らないテストは `tests/unit/` に置く。
+
+- E2E（`tests/e2e/`）は Bot の主要フロー（メッセージ受信 → URL 判定 → 取得 → 表示の組み立て → 送信）を通す。差し替えるのは **Discord と `fetch` の 2 箇所だけ**で、Core / Adapter は本物を動かす。外部 API を `ITwitterAdapter` ごと差し替えると単体テストと守備範囲が重なるため、`fetch` 層で差し替える。詳細は `tests/e2e/README.md` と ADR 0007。
+
+  ```bash
+  RUN_REDIS_INTEGRATION=1 REDIS_URL=redis://127.0.0.1:6390 npm run test:e2e
+  ```
+
+- **テストが噛んでいるか確かめてからコミットする**: 新しく書いたテストは、本番コードを一時的に壊して狙ったテストが落ちることを確認する。通ったことより、壊したときに落ちることのほうが情報量が多い。
 
 - **外部の実リソースを指すアサーションは、消えても気づけない**: 実在する URL のサイズや内容に依存するテストは、対象が消えた後もエラーページの応答で緑を返しうる（#607 で実例があった）。実 API を叩くテストは「取得できること・スキーマに適合すること」に留め、特定リソースの中身の値には依存させない。
 

--- a/docs/adr/0007-e2e-boundary-and-composition.md
+++ b/docs/adr/0007-e2e-boundary-and-composition.md
@@ -1,0 +1,111 @@
+# ADR 0007: E2E は Discord と fetch だけを差し替え、依存グラフはテスト側で組む
+
+- Status: Accepted
+- Date: 2026-08-13
+- Issue: #608
+
+## Context
+
+ADR 0006 で `tests/e2e/` を廃止した。置かれていた 2 つのテストが名前どおりのものでは
+なかったためである。結果として、Bot の主要フローを通しで検証するテストが存在しない状態が
+残った。#608 はこれを埋める。
+
+既存の `tests/unit/adapters/discord/MessageHandler.test.ts`（748 行）は、協力者を全て
+`vi.fn()` に差し替えている。
+
+```typescript
+processor      = { extractUrls: vi.fn().mockReturnValue([...]), ... }
+twitterAdapter = { fetchTweet: vi.fn().mockResolvedValue(createMockTweet()) }
+embedBuilder   = { build: vi.fn().mockReturnValue([]) }
+```
+
+`MessageHandler` が「どういう順で何を呼ぶか」は検証できるが、URL 抽出が返した文字列を
+Adapter が実際に解釈でき、そこから組んだ `Tweet` で表示が組めるかという**協調**は
+どのテストも見ていない。層ごとの単体テストが全て緑でも、繋いだ瞬間に壊れうる。
+
+## Decision
+
+### 1. 差し替えるのは外周の 2 箇所だけ
+
+| | 対象 |
+| --- | --- |
+| 本物 | `TweetProcessor`、`TwitterAdapter`（Vx→Fx フォールバック含む）、`ComponentsV2Builder`、`DiscordEmbedBuilder`、`ChannelConfigService`、`MediaHandler`、Redis |
+| 偽物 | Discord（`Message` / `Client`）、`fetch`（外部 Twitter API） |
+
+内側は本番と同じ実装を動かす。差し替えを増やすほど E2E は単体テストへ近づき、
+存在意義が薄れる。
+
+### 2. 外部 API は `ITwitterAdapter` ではなく `fetch` 層で差し替える
+
+`ITwitterAdapter` ごと差し替えると、生成クライアントのパースも `Tweet` への変換も
+フォールバックの分岐も通らない。守備範囲が既存の単体テストとほとんど重なる。
+
+`fetch` を差し替えれば、
+
+```
+生成クライアント → orvalFetch → VxTwitterAdapter / FxTwitterAdapter → TwitterAdapter
+```
+
+が全て本物のまま動く。既に `tests/unit/vxtwitter/apiHttpBoundary.test.ts` が同じ手法を
+使っている。
+
+`VxTwitterAdapter` / `FxTwitterAdapter` の `transformUrl` は `x.com` を
+`api.vxtwitter.com` / `api.fxtwitter.com` へ書き換えるため、ホスト名で応答を出し分ければ
+**「vx が 5xx を返して fx へフォールバックする」経路も意図的に再現できる**。fx 側には
+`tests/fixtures/fxtwitter/` の実 API payload をそのまま使う。
+
+想定外のホストへの `fetch` は reject する。黙って通すと、テストが気付かないうちに実
+ネットワークへ出る。
+
+### 3. 依存グラフはテスト側で組む
+
+`src/index.ts` は読み込み時点で全配線を実行し、そのまま Discord へログインする。
+テストから `import` できない。したがってテストが `index.ts` と同じ順で組み直す。
+
+### 4. 新しいテストは壊して確かめてからコミットする
+
+通ることではなく、**壊したときに落ちること**を確認する。#590 と #607 で、緑のまま何も
+検証していないテストが 2 度見つかっている。本 ADR のテストは、以下の 3 つを一時的に
+壊して、狙ったテストだけが落ちることを確認してからコミットした。
+
+| 壊した箇所 | 落ちたテスト |
+| --- | --- |
+| `ChannelConfigService` のホワイトリスト判定を常に true | ホワイトリスト外のチャンネルでは処理しない |
+| `TwitterAdapter` の 5xx フォールバック分岐を削除 | vx が 5xx を返すと fx へフォールバックして展開する |
+| `ComponentsV2Builder` の本文組み立てを空文字に | vx から取得した内容で Components v2 のメッセージを返す |
+
+## Consequences
+
+### Positive
+
+- 層をまたいだ協調が実際に検証されるようになった（7 ケース、CI で毎 PR 実行）。
+- Vx→Fx のフォールバックが、モックの戻り値ではなく HTTP ステータスから駆動されて
+  検証される。
+- FxTwitter の保存済み fixture が、パースだけでなく表示の組み立てまで通して使われる。
+- 外向き通信が全て遮断されるため、E2E がネットワーク都合で落ちない。
+
+### Negative
+
+- **`src/index.ts` 側の配線ミスは捕まらない**。テストは自分で組んだグラフを見ている
+  だけで、本番の合成が正しいことは保証しない。引数の順序違いのような配線ミスは
+  型で防がれるが、同じ型の依存を取り違えた場合は検知できない。
+- Discord のフェイクは `Message` の一部しか再現していない。discord.js 側の挙動変化
+  （API バージョン差異、ペイロード検証の厳格化）は検知できない。
+
+### Mitigation
+
+- 配線の共有は、`index.ts` から合成を関数へ切り出せば解消する。本番コードの
+  リファクタを伴うため本 PR では見送った。必要になった時点で切り出す。
+- Discord のペイロード検証は、`ContainerBuilder` を `toJSON()` まで落として中身を
+  確かめることで、少なくとも組み立て結果の妥当性は見ている。
+
+## Alternatives considered
+
+- **`ITwitterAdapter` を差し替える**: 実装は単純だが、Adapter の変換もフォールバックも
+  通らず、既存の単体テストに上乗せされる価値がほとんど無い。
+- **偽の API サーバーを Hono で立てる**: より実態に近いが、Adapter が URL をハード
+  コードで変換するため、ベース URL の差し替え口を本番コードへ開ける必要がある。
+  テストのために本番へ穴を開ける判断は、得られるものに見合わないと考えた。
+- **`tests/integration/` に置く**: 新しいディレクトリとスクリプトを増やさずに済むが、
+  Bot 全体を通すテストと部分結合のテストが同じ場所に混ざる。ADR 0006 が
+  「着手時に `tests/e2e/` を規約ごと再導入する」としていた方針に従った。

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test": "vitest",
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
+    "test:e2e": "vitest run tests/e2e",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "lint": "oxlint src/ tests/",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,84 @@
+# E2E テスト
+
+Bot の主要フローを通しで検証するテストを置く。
+
+```
+メッセージ受信 → URL 判定 → 投稿情報の取得 → 表示の組み立て → 送信
+```
+
+## 何を本物にして、何を偽物にするか
+
+E2E の値打ちは、この線引きで決まる。
+
+| | 対象 |
+| --- | --- |
+| **本物** | `TweetProcessor`、`TwitterAdapter`（Vx→Fx のフォールバック含む）、`ComponentsV2Builder`、`DiscordEmbedBuilder`、`ChannelConfigService`、`MediaHandler`、Redis |
+| **偽物** | Discord（`Message` / `Client`）、`fetch`（外部 Twitter API） |
+
+差し替えるのは**外周の 2 箇所だけ**。内側は本番と同じ実装が動く。
+
+`tests/unit/adapters/discord/MessageHandler.test.ts` は協力者を全て `vi.fn()` に
+差し替えるため、`MessageHandler` の手順は検証できても、URL 抽出が返した文字列を
+Adapter が解釈でき、その `Tweet` から表示が組めるかという**協調**は見ていない。
+E2E が埋めるのはそこ。
+
+### 外部 API は `fetch` 層で差し替える
+
+`ITwitterAdapter` ごと差し替えると、生成クライアントのパースも `Tweet` への変換も
+フォールバックの分岐も通らず、単体テストと守備範囲がほとんど重ならない。
+
+`twitterApiStub.ts` はホスト名でルーティングする。`transformUrl` が `x.com` を
+`api.vxtwitter.com` / `api.fxtwitter.com` へ書き換えるため、**vx を 5xx にして fx へ
+落とす経路も意図的に作れる**。
+
+```typescript
+stubTwitterApi({
+  vx: { kind: "status", status: 500 },
+  fx: { kind: "fixture", name: "status-text-only" }, // 実 API の保存済み payload
+});
+```
+
+想定外のホストへの `fetch` は reject する。黙って通すと、テストが気付かないうちに
+実ネットワークへ出てしまう。
+
+## 実行方法
+
+実 Redis が要るため `RUN_REDIS_INTEGRATION=1` のときだけ実行する。
+
+```bash
+docker run -d --rm --name twrx-test-redis -p 6390:6379 redis:8.2.2-alpine
+RUN_REDIS_INTEGRATION=1 REDIS_URL=redis://127.0.0.1:6390 npm run test:e2e
+docker rm -f twrx-test-redis
+```
+
+フラグ無しでは `skipped` として残る。空振りの緑にはしない（ADR 0006）。
+
+CI では `integration-redis` ジョブが Redis サービス付きで `tests/integration` と
+併せて実行する。
+
+## 書くときの約束
+
+- **依存の有無は `describe.skipIf(!RUN)` で表明する**。早期 `return` で緑にしない。
+- **被験体と同じ Redis 接続（`@/db/init` の `redis`）でデータを用意する**。別クライアントで
+  書くと「書いたのに読めない」状態を作り込む。
+- **書いたテストが本当に噛んでいるか確かめる**。本番コードを一時的に壊して、狙った
+  テストが落ちることを確認してからコミットする。通ったことより、壊したときに落ちる
+  ことのほうが情報量が多い。
+- **外部の実リソースの中身の値に依存しない**。対象が消えてもエラー応答で緑を返しうる。
+
+## 既知の限界
+
+`src/index.ts` は読み込み時点で Discord へログインするため、テストから `import` できない。
+依存グラフは**テスト側で index.ts と同じ順に組み直している**。したがって
+**index.ts 側の配線ミスはこのテストでは捕まらない**。
+
+配線を関数へ切り出して本番とテストで共有すれば解消するが、本番コードのリファクタを
+伴うため見送っている。経緯は ADR 0007 を参照。
+
+## ファイル
+
+| ファイル | 役割 |
+| --- | --- |
+| `messageFlow.test.ts` | メッセージ受信から送信までのシナリオ |
+| `twitterApiStub.ts` | 外部 Twitter API を `fetch` 層で差し替える |
+| `discordFake.ts` | `Message` / `Client` のフェイク。送信内容を記録する |

--- a/tests/e2e/discordFake.ts
+++ b/tests/e2e/discordFake.ts
@@ -1,0 +1,90 @@
+import { ChannelType, type Client, type Message } from "discord.js";
+import { vi } from "vitest";
+
+/**
+ * Discord 境界のフェイク。
+ *
+ * discord.js の Client / Message は gateway 接続を前提とするため、E2E ではここを
+ * 境界にする。Bot が「何を送ろうとしたか」を記録し、テストから検証できるようにする。
+ */
+
+/** message.reply() / channel.send() に渡されたペイロード */
+export type SentPayload = Record<string, unknown> | string;
+
+export interface FakeMessage {
+  /** MessageHandler へ渡す Message 相当のオブジェクト */
+  readonly message: Message;
+  /** reply() に渡されたペイロードを送信順に記録したもの */
+  readonly replies: SentPayload[];
+  /** channel.send() に渡されたペイロードを送信順に記録したもの */
+  readonly channelSends: SentPayload[];
+  /** suppressEmbeds() が呼ばれたか（1件以上展開できたときだけ呼ばれる） */
+  wasSuppressed: () => boolean;
+}
+
+export interface FakeMessageOptions {
+  content: string;
+  guildId?: string | null;
+  channelId?: string;
+  authorId?: string;
+  messageId?: string;
+}
+
+export const createFakeClient = (): Client =>
+  ({
+    user: { id: "bot-user-id" },
+    on: vi.fn(),
+  }) as unknown as Client;
+
+/**
+ * Message のフェイクを作る
+ *
+ * guild は null にしている。MessageHandler は guild が無いときチャンネル一覧の
+ * 再取得をスキップし、添付上限は既定へ倒れる。ここで見たいのは URL 受信から
+ * 送信までの経路であり、ギルドのブーストレベル依存の分岐ではない。
+ */
+export const createFakeMessage = (options: FakeMessageOptions): FakeMessage => {
+  const replies: SentPayload[] = [];
+  const channelSends: SentPayload[] = [];
+  let suppressed = false;
+
+  let replyCounter = 0;
+
+  const message = {
+    id: options.messageId ?? "msg-id",
+    content: options.content,
+    guildId: options.guildId === undefined ? "guild-id" : options.guildId,
+    channelId: options.channelId ?? "channel-id",
+    guild: null,
+    author: { bot: false, id: options.authorId ?? "user-id" },
+    channel: {
+      type: ChannelType.GuildText,
+      sendTyping: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn((payload: SentPayload) => {
+        channelSends.push(payload);
+        return Promise.resolve({ id: `channel-msg-${channelSends.length}` });
+      }),
+    },
+    reply: vi.fn((payload: SentPayload) => {
+      replies.push(payload);
+      replyCounter += 1;
+      return Promise.resolve({
+        id: `reply-msg-${replyCounter}`,
+        edit: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        createMessageComponentCollector: vi.fn().mockReturnValue({ on: vi.fn() }),
+      });
+    }),
+    suppressEmbeds: vi.fn((value: boolean) => {
+      suppressed = value;
+      return Promise.resolve(undefined);
+    }),
+  } as unknown as Message;
+
+  return {
+    message,
+    replies,
+    channelSends,
+    wasSuppressed: () => suppressed,
+  };
+};

--- a/tests/e2e/messageFlow.test.ts
+++ b/tests/e2e/messageFlow.test.ts
@@ -1,0 +1,285 @@
+import path from "node:path";
+
+import type { GuildConfig } from "@rx-twitter/shared";
+import { ContainerBuilder } from "discord.js";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { ComponentsV2Builder } from "@/adapters/discord/ComponentsV2Builder";
+import { DiscordEmbedBuilder } from "@/adapters/discord/EmbedBuilder";
+import { MessageHandler } from "@/adapters/discord/MessageHandler";
+import { TwitterAdapter } from "@/adapters/twitter/TwitterAdapter";
+import { ArticlePostService } from "@/core/services/ArticlePostService";
+import { BanService } from "@/core/services/BanService";
+import { ChannelConfigService, type FallbackPolicies } from "@/core/services/ChannelConfigService";
+import { MediaHandler } from "@/core/services/MediaHandler";
+import { TweetProcessor } from "@/core/services/TweetProcessor";
+import { redis } from "@/db/init";
+import { RedisArticlePostRepository } from "@/infrastructure/db/RedisArticlePostRepository";
+import { RedisBanRepository } from "@/infrastructure/db/RedisBanRepository";
+import { RedisChannelConfigRepository } from "@/infrastructure/db/RedisChannelConfigRepository";
+import { RedisReplyLogger } from "@/infrastructure/db/RedisReplyLogger";
+import { FileManager } from "@/infrastructure/filesystem/FileManager";
+import { HttpClient } from "@/infrastructure/http/HttpClient";
+import { VideoDownloader } from "@/infrastructure/http/VideoDownloader";
+
+import { createFakeClient, createFakeMessage } from "./discordFake";
+import { stubTwitterApi, vxStatus } from "./twitterApiStub";
+
+/**
+ * Bot の主要フローを通す E2E テスト。
+ *
+ *   メッセージ受信 → URL 判定 → 投稿情報の取得 → 表示の組み立て → 送信
+ *
+ * tests/unit/adapters/discord/MessageHandler.test.ts は協力者を全て vi.fn() に
+ * 差し替えるため、MessageHandler の手順は検証できても「実際の協調」は見ていない。
+ * ここでは Core / Adapter を本物のまま組み、外側の 2 箇所だけを差し替える。
+ *
+ *   本物: TweetProcessor / TwitterAdapter(Vx→Fx) / ComponentsV2Builder /
+ *         DiscordEmbedBuilder / ChannelConfigService / Redis
+ *   偽物: Discord（Message・Client）と fetch（外部 Twitter API）
+ *
+ * 依存グラフは src/index.ts と同じ順で組む。index.ts は読み込み時点で Discord へ
+ * ログインするため import できず、配線はテスト側で再現している。したがって
+ * index.ts 側の配線ミスはこのテストでは捕まらない（ADR 0007 参照）。
+ *
+ * 実行には Redis が必要なため、RUN_REDIS_INTEGRATION=1 のときだけ実行する。
+ *   RUN_REDIS_INTEGRATION=1 REDIS_URL=redis://127.0.0.1:6390 npm run test:e2e
+ */
+const RUN = process.env.RUN_REDIS_INTEGRATION === "1";
+
+/** fixture・vx スタブと揃えた、テストで送信するツイート URL */
+const TWEET_URL = "https://x.com/test_user/status/1870044090072739960";
+
+const configKey = (guildId: string): string => `app:guild:${guildId}:config`;
+
+const generateTestGuildId = (): string => `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const policies: FallbackPolicies = { redisDown: "deny", configNotFound: "deny" };
+
+/** ギルド設定を実 Redis へ書く。Repository と同じ接続を使う */
+const seedGuildConfig = async (guildId: string, overrides: Partial<GuildConfig> = {}): Promise<void> => {
+  const config: GuildConfig = {
+    guildId,
+    allowAllChannels: true,
+    whitelistedChannelIds: [],
+    version: 1,
+    updatedAt: "2026-08-13T00:00:00.000Z",
+    ...overrides,
+  };
+  await redis.set(configKey(guildId), JSON.stringify(config));
+};
+
+describe.skipIf(!RUN)("Bot メッセージフロー (e2e, real Redis)", () => {
+  let handler: MessageHandler;
+  let channelConfigRepository: RedisChannelConfigRepository;
+  let testGuildId: string;
+
+  const client = createFakeClient();
+
+  beforeAll(async () => {
+    if (!redis.isOpen) await redis.connect();
+  });
+
+  afterAll(async () => {
+    if (redis.isOpen) await redis.quit();
+  });
+
+  beforeEach(async () => {
+    testGuildId = generateTestGuildId();
+
+    // --- src/index.ts と同じ順で組む ---
+    // Infrastructure 層
+    const httpClient = new HttpClient();
+    const fileManager = new FileManager(path.join("/tmp", "twitterrx-e2e"));
+    const videoDownloader = new VideoDownloader();
+    const replyLogger = new RedisReplyLogger();
+
+    // Core 層
+    const tweetProcessor = new TweetProcessor();
+    const articlePostService = new ArticlePostService(new RedisArticlePostRepository());
+    const mediaHandler = new MediaHandler(httpClient);
+    channelConfigRepository = new RedisChannelConfigRepository();
+    const channelConfigService = new ChannelConfigService(channelConfigRepository, policies);
+    const banService = new BanService(new RedisBanRepository());
+
+    // Adapter 層
+    const twitterAdapter = TwitterAdapter.createDefault();
+    const embedBuilder = new DiscordEmbedBuilder();
+    const componentsV2Builder = new ComponentsV2Builder();
+
+    handler = new MessageHandler(
+      tweetProcessor,
+      twitterAdapter,
+      embedBuilder,
+      componentsV2Builder,
+      mediaHandler,
+      fileManager,
+      videoDownloader,
+      replyLogger,
+      path.join("/tmp", "twitterrx-e2e"),
+      channelConfigService,
+      banService,
+      articlePostService
+    );
+
+    // Repository の Pub/Sub 購読が張られるまで待つ（未完了で shutdown するとタイマーが残る）
+    await vi.waitFor(async () => {
+      const subscribers = await redis.pubSubNumSub("config:update");
+      expect(subscribers["config:update"]).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await channelConfigRepository.shutdown();
+    await redis.del(configKey(testGuildId)).catch(() => undefined);
+  });
+
+  describe("対応 URL を受信すると展開して返す", () => {
+    it("vx から取得した内容で Components v2 のメッセージを返す", async () => {
+      await seedGuildConfig(testGuildId);
+      stubTwitterApi({
+        vx: { kind: "json", body: vxStatus({ text: "これはテスト投稿です" }) },
+        // vx が成功するのでフォールバックは起きない。呼ばれたら落ちるようにしておく
+        fx: { kind: "status", status: 500 },
+      });
+
+      const fake = createFakeMessage({ content: `見て ${TWEET_URL}`, guildId: testGuildId });
+      await handler.handleMessage(client, fake.message);
+
+      expect(fake.replies).toHaveLength(1);
+
+      const payload = fake.replies[0] as Record<string, unknown>;
+      const components = payload.components as ContainerBuilder[];
+      expect(components).toHaveLength(1);
+      expect(components[0]).toBeInstanceOf(ContainerBuilder);
+
+      // Container に本文と著者が載っていること。JSON まで落として中身を確かめる
+      const rendered = JSON.stringify(components[0].toJSON());
+      expect(rendered).toContain("これはテスト投稿です");
+      expect(rendered).toContain("test_user");
+
+      // 展開できたので元メッセージの埋め込みは抑制される
+      expect(fake.wasSuppressed()).toBe(true);
+    });
+
+    it("ツイート URL が無いメッセージには何も返さない", async () => {
+      await seedGuildConfig(testGuildId);
+      stubTwitterApi({
+        // URL が無ければ API は一切呼ばれないはず
+        vx: { kind: "status", status: 500 },
+        fx: { kind: "status", status: 500 },
+      });
+
+      const fake = createFakeMessage({ content: "ただの雑談", guildId: testGuildId });
+      await handler.handleMessage(client, fake.message);
+
+      expect(fake.replies).toHaveLength(0);
+      expect(fake.wasSuppressed()).toBe(false);
+    });
+  });
+
+  describe("チャンネル許可", () => {
+    it("ホワイトリスト外のチャンネルでは処理しない", async () => {
+      await seedGuildConfig(testGuildId, {
+        allowAllChannels: false,
+        whitelistedChannelIds: ["allowed-channel"],
+      });
+      const stub = stubTwitterApi({
+        vx: { kind: "json", body: vxStatus() },
+        fx: { kind: "fixture", name: "status-text-only" },
+      });
+
+      const fake = createFakeMessage({
+        content: `見て ${TWEET_URL}`,
+        guildId: testGuildId,
+        channelId: "not-in-list",
+      });
+      await handler.handleMessage(client, fake.message);
+
+      expect(fake.replies).toHaveLength(0);
+      // 許可判定で弾くので、外部 API は呼ばれない
+      expect(stub.calls).toHaveLength(0);
+    });
+
+    it("ホワイトリスト内のチャンネルでは処理する", async () => {
+      await seedGuildConfig(testGuildId, {
+        allowAllChannels: false,
+        whitelistedChannelIds: ["allowed-channel"],
+      });
+      stubTwitterApi({
+        vx: { kind: "json", body: vxStatus() },
+        fx: { kind: "status", status: 500 },
+      });
+
+      const fake = createFakeMessage({
+        content: `見て ${TWEET_URL}`,
+        guildId: testGuildId,
+        channelId: "allowed-channel",
+      });
+      await handler.handleMessage(client, fake.message);
+
+      expect(fake.replies).toHaveLength(1);
+    });
+
+    it("設定が存在しない場合、configNotFound=deny に従って処理しない", async () => {
+      // 設定を書かない
+      const stub = stubTwitterApi({
+        vx: { kind: "json", body: vxStatus() },
+        fx: { kind: "status", status: 500 },
+      });
+
+      const fake = createFakeMessage({ content: `見て ${TWEET_URL}`, guildId: testGuildId });
+      await handler.handleMessage(client, fake.message);
+
+      expect(fake.replies).toHaveLength(0);
+      expect(stub.calls).toHaveLength(0);
+    });
+  });
+
+  describe("外部 API の失敗", () => {
+    it("vx が 5xx を返すと fx へフォールバックして展開する", async () => {
+      await seedGuildConfig(testGuildId);
+      const stub = stubTwitterApi({
+        vx: { kind: "status", status: 500, body: "<html>Internal Server Error</html>" },
+        // 実 API の保存済み payload をそのまま返す
+        fx: { kind: "fixture", name: "status-text-only" },
+      });
+
+      const fake = createFakeMessage({ content: `見て ${TWEET_URL}`, guildId: testGuildId });
+      await handler.handleMessage(client, fake.message);
+
+      // 両方のホストへ到達している = フォールバックが働いた
+      expect(stub.calls.some((url) => url.includes("api.vxtwitter.com"))).toBe(true);
+      expect(stub.calls.some((url) => url.includes("api.fxtwitter.com"))).toBe(true);
+
+      expect(fake.replies).toHaveLength(1);
+      const payload = fake.replies[0] as Record<string, unknown>;
+      const components = payload.components as ContainerBuilder[];
+      expect(components[0]).toBeInstanceOf(ContainerBuilder);
+      expect(fake.wasSuppressed()).toBe(true);
+    });
+
+    it("vx と fx の両方が失敗するとエラーを返信する", async () => {
+      await seedGuildConfig(testGuildId);
+      stubTwitterApi({
+        vx: { kind: "status", status: 500, body: "<html>Internal Server Error</html>" },
+        fx: { kind: "status", status: 500, body: "<html>Internal Server Error</html>" },
+      });
+
+      const fake = createFakeMessage({ content: `見て ${TWEET_URL}`, guildId: testGuildId });
+      await handler.handleMessage(client, fake.message);
+
+      expect(fake.replies).toHaveLength(1);
+      const payload = fake.replies[0] as Record<string, unknown>;
+      expect(payload.content).toBe("ツイートの取得に失敗しました。");
+
+      // 展開できていないので元メッセージの埋め込みは抑制しない
+      expect(fake.wasSuppressed()).toBe(false);
+    });
+  });
+});

--- a/tests/e2e/twitterApiStub.ts
+++ b/tests/e2e/twitterApiStub.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { vi } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.resolve(__dirname, "../fixtures/fxtwitter");
+
+/**
+ * 外部 Twitter API（vxTwitter / FxTwitter）を fetch 層で差し替えるスタブ。
+ *
+ * ITwitterAdapter ごと差し替えると、生成クライアントのパースも Tweet への変換も
+ * フォールバックの分岐も通らず、守備範囲が単体テストとほとんど重ならない。
+ * ここでは fetch だけを差し替えることで、
+ *   生成クライアント → orvalFetch → VxTwitterAdapter / FxTwitterAdapter → TwitterAdapter
+ * を全て本物のまま通す。
+ *
+ * VxTwitterAdapter / FxTwitterAdapter の transformUrl は
+ * `x.com` を `api.vxtwitter.com` / `api.fxtwitter.com` へ書き換えるため、
+ * ホスト名で応答を出し分ければ「vx が落ちて fx へフォールバックする」経路も再現できる。
+ */
+
+/** 1 ホストぶんの応答の決め方 */
+export type StubResponse =
+  | { kind: "json"; body: unknown }
+  /** FxTwitter の保存済み fixture をそのまま返す（tests/fixtures/fxtwitter/<name>.json） */
+  | { kind: "fixture"; name: string }
+  | { kind: "status"; status: number; body?: string; contentType?: string };
+
+export interface TwitterApiStubPlan {
+  /** api.vxtwitter.com への応答 */
+  vx: StubResponse;
+  /** api.fxtwitter.com への応答 */
+  fx: StubResponse;
+}
+
+/** 保存済み fixture を読む。実 API の payload をそのまま置いてあるもの */
+export const readFixture = (name: string): unknown =>
+  JSON.parse(fs.readFileSync(path.join(FIXTURE_DIR, `${name}.json`), "utf8"));
+
+const toResponse = (spec: StubResponse): Response => {
+  switch (spec.kind) {
+    case "json":
+      return new Response(JSON.stringify(spec.body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    case "fixture":
+      return new Response(JSON.stringify(readFixture(spec.name)), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    case "status":
+      return new Response(spec.body ?? "", {
+        status: spec.status,
+        headers: { "content-type": spec.contentType ?? "text/html" },
+      });
+  }
+};
+
+export interface TwitterApiStub {
+  /** 実際に要求された URL の一覧。どのアダプタまで到達したかを検証できる */
+  readonly calls: string[];
+}
+
+/**
+ * fetch をホスト名でルーティングするスタブに差し替える。
+ *
+ * 解除は vi.unstubAllGlobals()（afterEach で呼ぶこと）。
+ */
+export const stubTwitterApi = (plan: TwitterApiStubPlan): TwitterApiStub => {
+  const calls: string[] = [];
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: unknown) => {
+      // fetch の第一引数は文字列・URL・Request のいずれも取りうる
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : String((input as { url?: unknown }).url);
+      calls.push(url);
+
+      const { hostname } = new URL(url);
+
+      if (hostname === "api.vxtwitter.com") {
+        return Promise.resolve(toResponse(plan.vx));
+      }
+
+      if (hostname === "api.fxtwitter.com") {
+        return Promise.resolve(toResponse(plan.fx));
+      }
+
+      // 想定外の外向き通信は、握りつぶさず落とす。
+      // 黙って通すと、テストが気付かないうちに実ネットワークへ出てしまう。
+      return Promise.reject(new Error(`[e2e] 想定外の fetch: ${url}`));
+    })
+  );
+
+  return { calls };
+};
+
+/**
+ * vxTwitter の正常応答を組み立てる
+ *
+ * vx には保存済み fixture が無いため、生成スキーマ（VxTwitterStatus）の必須項目を
+ * 満たす最小の payload をここで組む。fx 側は実 API の fixture を使うので、
+ * 「手書きの思い込み」だけでフローを検証することにはならない。
+ */
+export const vxStatus = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  date: "Sun Dec 22 12:00:00 +0000 2024",
+  likes: 100,
+  replies: 10,
+  retweets: 50,
+  text: "vx から取得した本文",
+  tweetURL: "https://x.com/test_user/status/1870044090072739960",
+  user_name: "Test User",
+  user_screen_name: "test_user",
+  user_profile_image_url: "https://pbs.twimg.com/profile_images/test.jpg",
+  mediaURLs: [],
+  media_extended: [],
+  ...overrides,
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,9 +20,13 @@ export default defineConfig({
       exclude: [
         "node_modules/",
         "dist/",
+        // テストコードは計測対象ではない。*.test.ts だけを除くと、
+        // ヘルパーやフェイク（tests/e2e/discordFake.ts 等）が素通りして
+        // 計測に混ざる。依存を要するテストが skip された実行では、
+        // それらは import されるだけで実行率が落ち、数字を歪める。
+        "tests/**",
         "**/*.test.ts",
         "**/*.spec.ts",
-        "**/fixtures/**",
         "src/**/generated/**",
       ],
     },


### PR DESCRIPTION
## 概要

#590 で `tests/e2e/` を廃止して以来、Bot の主要フローを通しで検証するテストが存在しなかった。ADR 0006 が「着手時に規約ごと再導入する」としていたものを実装する。

Closes #608

## 埋めた穴

`tests/unit/adapters/discord/MessageHandler.test.ts`（748 行）は、協力者を**全て** `vi.fn()` に差し替えている。

```typescript
processor      = { extractUrls: vi.fn().mockReturnValue([...]), ... }
twitterAdapter = { fetchTweet: vi.fn().mockResolvedValue(createMockTweet()) }
embedBuilder   = { build: vi.fn().mockReturnValue([]) }
```

`MessageHandler` が「どういう順で何を呼ぶか」は検証できるが、URL 抽出が返した文字列を Adapter が実際に解釈でき、そこから組んだ `Tweet` で表示が組めるかという**協調**はどのテストも見ていなかった。層ごとの単体テストが全て緑でも、繋いだ瞬間に壊れうる。

## 設計: 何を本物にして、何を偽物にするか

E2E の値打ちはこの線引きで決まる。差し替えを増やすほど単体テストへ近づき、存在意義が薄れる。

| | 対象 |
| --- | --- |
| **本物** | `TweetProcessor`、`TwitterAdapter`（Vx→Fx フォールバック含む）、`ComponentsV2Builder`、`DiscordEmbedBuilder`、`ChannelConfigService`、`MediaHandler`、Redis |
| **偽物** | Discord（`Message` / `Client`）、`fetch`（外部 Twitter API） |

### 外部 API は `ITwitterAdapter` ではなく `fetch` 層で差し替える

前者だと生成クライアントのパースも `Tweet` への変換もフォールバックの分岐も通らず、既存の単体テストに上乗せされる価値がほとんど無い。`fetch` を差し替えれば以下が全て本物のまま動く。

```
生成クライアント → orvalFetch → VxTwitterAdapter / FxTwitterAdapter → TwitterAdapter
```

`transformUrl` が `x.com` を `api.vxtwitter.com` / `api.fxtwitter.com` へ書き換える性質を使い、ホスト名で応答を出し分ける。これで**「vx が 5xx を返して fx へフォールバックする」経路も意図的に再現できる**。fx 側は `tests/fixtures/fxtwitter/` の実 API payload をそのまま返す。

```typescript
stubTwitterApi({
  vx: { kind: "status", status: 500 },
  fx: { kind: "fixture", name: "status-text-only" },
});
```

想定外のホストへの `fetch` は reject する。黙って通すと、テストが気付かないうちに実ネットワークへ出てしまう。

## 検証したこと: テストが本当に噛んでいるか

7 件が一発で緑になったので、**本番コードを一時的に壊して狙ったテストが落ちるか**を確かめた。#590 と #607 で緑のまま何も検証していないテストが 2 度見つかっているため、通ったことだけでは信用しない。

| 壊した箇所 | 落ちたテスト |
| --- | --- |
| `ChannelConfigService` のホワイトリスト判定を常に `true` | ホワイトリスト外のチャンネルでは処理しない |
| `TwitterAdapter` の 5xx フォールバック分岐を削除 | vx が 5xx を返すと fx へフォールバックして展開する |
| `ComponentsV2Builder` の本文組み立てを空文字に | vx から取得した内容で Components v2 のメッセージを返す |

いずれも狙ったテスト 1 件だけが落ち、他の 6 件は緑のままだった。確認後、本番コードは復元済み（差分は `tests/e2e/` と設定ファイルのみ）。

## シナリオ

- 対応 URL を受信すると Components v2 のメッセージを返す（本文・著者が Container に載ることまで `toJSON()` で確認）
- URL が無いメッセージには何も返さない
- ホワイトリスト外のチャンネルでは処理しない（外部 API が 1 度も呼ばれないことも確認）
- ホワイトリスト内のチャンネルでは処理する
- 設定が存在しない場合は `configNotFound=deny` に従う
- vx が 5xx なら fx へフォールバックして展開する
- vx と fx の両方が失敗するとエラーを返信し、元メッセージの埋め込みを抑制しない

## 動作確認

```bash
docker run -d --rm --name twrx-608-redis -p 6393:6379 redis:8.2.2-alpine
RUN_REDIS_INTEGRATION=1 REDIS_URL=redis://127.0.0.1:6393 npx vitest run tests/integration tests/e2e
#  Test Files  3 passed | 2 skipped (5)
#       Tests  22 passed | 15 skipped (37)
```

フラグ無しでは空振りの緑ではなく `skipped` として残る。

```bash
npx vitest run tests/e2e
#  Test Files  1 skipped (1)
#       Tests  7 skipped (7)
```

## 品質ゲート

| ゲート | 結果 |
| --- | --- |
| `npx oxlint src/ tests/` | 0 |
| `npx oxfmt --check src/` | 0 |
| `npm run compile:test` | 0 |
| `npm run compile:tests` | 0 |
| `npm run build` | 0 |
| `npm run test:unit` | 531 passed (35 files) |

## レビューで見てほしい点

**`src/index.ts` 側の配線ミスは、このテストでは捕まらない。**

`index.ts` は読み込み時点で全配線を実行しそのまま Discord へログインするため `import` できず、依存グラフはテスト側で同じ順に組み直している。つまりテストは自分で組んだグラフを見ているだけで、本番の合成が正しいことは保証しない。引数の順序違いは型で防がれるが、同じ型の依存を取り違えた場合は検知できない。

`index.ts` から合成を関数へ切り出して本番とテストで共有すれば解消するが、本番コードのリファクタを伴うため見送った。ADR 0007 の Negative に明記してある。切り出すべきなら別 Issue で対応する。

## 関連

- Closes #608
- ADR 0007（新規） — E2E の境界設計
- ADR 0006 — 「着手時に `tests/e2e/` を規約ごと再導入する」としていた方針

🤖 Generated with [Claude Code](https://claude.com/claude-code)
